### PR TITLE
Made doe/pricing mrid's globally unique

### DIFF
--- a/src/envoy/server/mapper/csip_aus/doe.py
+++ b/src/envoy/server/mapper/csip_aus/doe.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from typing import Sequence
 
+from envoy.server.mapper.common import generate_mrid
 from envoy.server.model.doe import DOE_DECIMAL_PLACES, DOE_DECIMAL_POWER, DynamicOperatingEnvelope
 from envoy.server.schema import uri
 from envoy.server.schema.sep2.der import (
@@ -15,7 +16,7 @@ from envoy.server.schema.sep2.identification import ListLink
 from envoy.server.schema.sep2.pricing import PrimacyType
 from envoy.server.schema.sep2.types import DateTimeIntervalType
 
-DOE_PROGRAM_MRID: str = "d0e"
+DOE_PROGRAM_MRID_PREFIX: int = int("D0E", 16)
 DOE_PROGRAM_ID: str = "doe"
 
 
@@ -35,7 +36,7 @@ class DERControlMapper:
         """Creates a csip aus compliant DERControlResponse from the specific doe"""
         return DERControlResponse.validate(
             {
-                "mRID": f"{doe.dynamic_operating_envelope_id:x}",  # mrid must be a hex encoded string
+                "mRID": generate_mrid(DOE_PROGRAM_MRID_PREFIX, doe.site_id, doe.dynamic_operating_envelope_id),
                 "version": 1,
                 "description": doe.start_time.isoformat(),
                 "interval": DateTimeIntervalType.validate(
@@ -92,7 +93,7 @@ class DERProgramMapper:
         return DERProgramResponse.validate(
             {
                 "href": DERProgramMapper.doe_href(site_id),
-                "mRID": f"{DOE_PROGRAM_MRID}{site_id:x}",  # mrid must be a hex encoded string
+                "mRID": generate_mrid(DOE_PROGRAM_MRID_PREFIX, site_id),
                 "primacy": PrimacyType.IN_HOME_ENERGY_MANAGEMENT_SYSTEM,
                 "description": "Dynamic Operating Envelope",
                 "DERControlListLink": ListLink.validate(

--- a/src/envoy/server/mapper/sep2/pricing.py
+++ b/src/envoy/server/mapper/sep2/pricing.py
@@ -32,6 +32,9 @@ from envoy.server.schema.sep2.types import (
     UomType,
 )
 
+TARIFF_PROFILE_MRID_PREFIX: int = int("B111", 16)
+RATE_MRID_PREFIX: int = int("D01A", 16)
+
 
 class TariffProfileMapper:
     @staticmethod
@@ -39,7 +42,7 @@ class TariffProfileMapper:
         return TariffProfileResponse.validate(
             {
                 "href": tp_href,
-                "mRID": f"{tariff.tariff_id:x}",
+                "mRID": generate_mrid(TARIFF_PROFILE_MRID_PREFIX, tariff.tariff_id),
                 "description": tariff.name,
                 "currency": tariff.currency_code,
                 "pricePowerOfTenMultiplier": PRICE_DECIMAL_PLACES,
@@ -192,7 +195,7 @@ class RateComponentMapper:
         return RateComponentResponse.validate(
             {
                 "href": rc_href,
-                "mRID": generate_mrid(tariff_id, site_id, start_timestamp, pricing_reading),
+                "mRID": generate_mrid(TARIFF_PROFILE_MRID_PREFIX, tariff_id, site_id, start_timestamp, pricing_reading),
                 "description": pricing_reading.name,
                 "roleFlags": RoleFlagsType.NONE,
                 "ReadingTypeLink": Link(href=PricingReadingTypeMapper.pricing_reading_type_href(pricing_reading)),
@@ -316,7 +319,11 @@ class TimeTariffIntervalMapper:
         return TimeTariffIntervalResponse.validate(
             {
                 "href": href,
-                "mRID": f"{rate.tariff_generated_rate_id:x}",
+                "mRID": generate_mrid(
+                    RATE_MRID_PREFIX,
+                    rate.tariff_generated_rate_id,
+                    pricing_reading,
+                ),
                 "version": 0,
                 "description": rate.start_time.isoformat(),
                 "touTier": TOUType.NOT_APPLICABLE,

--- a/tests/unit/server/mapper/csip_aus/test_doe.py
+++ b/tests/unit/server/mapper/csip_aus/test_doe.py
@@ -111,3 +111,15 @@ def test_map_derp_doe_program_list_response():
     assert all([isinstance(p, DERProgramResponse) for p in result.DERProgram])
     assert result.all_ == 1
     assert result.results == 1
+
+
+def test_mrid_uniqueness():
+    """Test our mrids for controls differ from programs even when the ID's are the same"""
+    site_id = 1
+    doe: DynamicOperatingEnvelope = generate_class_instance(DynamicOperatingEnvelope)
+    doe.site_id = site_id
+    doe.dynamic_operating_envelope_id = site_id  # intentionally the same as site_id
+
+    program = DERProgramMapper.doe_program_response(site_id, 999)
+    control = DERControlMapper.map_to_response(doe)
+    assert program.mRID != control.mRID


### PR DESCRIPTION
Fix for https://github.com/bsgip/envoy/issues/43

mrid's should now be "namespaced" under a unique prefix such that a tariff with ID 1 will now have a different mrid from a DOE with ID 1