### PR TITLE
Add csip aus namespace to EndDevice.ConnectionPointLink

### DIFF
--- a/src/envoy/server/schema/sep2/end_device.py
+++ b/src/envoy/server/schema/sep2/end_device.py
@@ -22,8 +22,10 @@ class EndDeviceResponse(EndDeviceRequest, tag="EndDevice"):
     changedTime: TimeType = element()
     enabled: Optional[int] = element(default=1)
 
-    # Links
-    ConnectionPointLink: Optional[ConnectionPointLinkType] = element()
+    # csip extension
+    ConnectionPointLink: Optional[ConnectionPointLinkType] = element(ns="csipaus")
+
+    # sep2 Links
     ConfigurationLink: Optional[str] = element()
     DeviceInformationLink: Optional[Link] = element()
     DeviceStatusLink: Optional[Link] = element()


### PR DESCRIPTION
The ConnectionPointLink in EndDevice is currently incorrectly tagged as sep2 