### PR TITLE
Refactored cert_pem_header

### DIFF
--- a/src/envoy/server/api/depends.py
+++ b/src/envoy/server/api/depends.py
@@ -17,16 +17,16 @@ class LFDIAuthDepends:
     Definition of LFDI can be found in the IEEE Std 2030.5-2018 on page 40.
     """
 
-    def __init__(self, cert_pem_header: str):
-        self.cert_pem_header = cert_pem_header
+    def __init__(self, cert_header: str):
+        self.cert_header = cert_header.lower()  # fastapi will always return headers in lowercase form
 
     async def __call__(self, request: Request):
-        if self.cert_pem_header not in request.headers.keys():
+        if self.cert_header not in request.headers.keys():
             raise HTTPException(
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Missing certificate PEM header from gateway."
             )
 
-        cert_fingerprint = request.headers[self.cert_pem_header]
+        cert_fingerprint = request.headers[self.cert_header]
 
         # generate lfdi
         lfdi = LFDIAuthDepends.generate_lfdi_from_fingerprint(cert_fingerprint)

--- a/src/envoy/server/main.py
+++ b/src/envoy/server/main.py
@@ -12,7 +12,7 @@ from envoy.server.settings import AppSettings, settings
 
 def generate_app(new_settings: AppSettings):
     """Generates a new app instance utilising the specific settings instance"""
-    lfdi_auth = LFDIAuthDepends(new_settings.cert_pem_header)
+    lfdi_auth = LFDIAuthDepends(new_settings.cert_header)
     new_app = FastAPI(**new_settings.fastapi_kwargs, dependencies=[Depends(lfdi_auth)])
     new_app.add_middleware(SQLAlchemyMiddleware, **new_settings.db_middleware_kwargs)
     for router in routers:

--- a/src/envoy/server/settings.py
+++ b/src/envoy/server/settings.py
@@ -12,7 +12,7 @@ class AppSettings(BaseSettings):
     title: str = "envoy"
     version: str = "0.0.0"
 
-    cert_pem_header: str = "x-forwarded-client-cert"
+    cert_header: str = "x-forwarded-client-cert"
     default_timezone: str = "Australia/Brisbane"
 
     database_url: PostgresDsn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,11 +25,15 @@ if test_with_docker:
 
 
 @pytest.fixture
-def pg_empty_config(postgresql) -> Connection:
+def pg_empty_config(postgresql, request: pytest.FixtureRequest) -> Connection:
     """Sets up the testing DB, applies alembic migrations but does NOT add any entities"""
 
     # Install the DATABASE_URL before running alembic
     os.environ["DATABASE_URL"] = generate_async_conn_str_from_connection(postgresql)
+
+    pem_marker = request.node.get_closest_marker("cert_header")
+    if pem_marker is not None:
+        os.environ["CERT_HEADER"] = str(pem_marker.args[0])
 
     # we want alembic to run from the server directory but to revert back afterwards
     cwd = os.getcwd()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,7 @@ from envoy.admin.settings import generate_settings as admin_gen_settings
 from envoy.server.main import generate_app
 from envoy.server.settings import generate_settings
 from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as VALID_CERT
-from tests.integration.integration_server import cert_pem_header
+from tests.integration.integration_server import cert_header
 
 
 @pytest.fixture
@@ -26,7 +26,7 @@ async def client(pg_base_config: Connection):
 
 @pytest.fixture
 def valid_headers():
-    return {cert_pem_header: urllib.parse.quote(VALID_CERT)}
+    return {cert_header: urllib.parse.quote(VALID_CERT)}
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/func_sets/test_connection_point.py
+++ b/tests/integration/func_sets/test_connection_point.py
@@ -10,7 +10,7 @@ from envoy.server.schema.csip_aus.connection_point import ConnectionPointRequest
 from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as AGG_1_VALID_CERT
 from tests.data.certificates.certificate4 import TEST_CERTIFICATE_FINGERPRINT as AGG_2_VALID_CERT
 from tests.data.certificates.certificate5 import TEST_CERTIFICATE_FINGERPRINT as AGG_3_VALID_CERT
-from tests.integration.integration_server import cert_pem_header
+from tests.integration.integration_server import cert_header
 from tests.integration.response import (
     assert_error_response,
     assert_response_header,
@@ -47,7 +47,7 @@ async def test_get_connectionpoint(
 ):
     """Tests getting a variety of connection points for the sites - tests successful / unsuccessful responses"""
     response = await client.get(
-        connection_point_uri_format.format(site_id=site_id), headers={cert_pem_header: urllib.parse.quote(cert)}
+        connection_point_uri_format.format(site_id=site_id), headers={cert_header: urllib.parse.quote(cert)}
     )
     assert_response_header(response, expected_status_response)
 
@@ -71,7 +71,7 @@ async def test_get_connectionpoint_none_nmi(
         pg_base_config.commit()
 
     response = await client.get(
-        connection_point_uri_format.format(site_id=1), headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)}
+        connection_point_uri_format.format(site_id=1), headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)}
     )
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
@@ -88,7 +88,7 @@ async def test_connectionpoint_update_and_fetch(client: AsyncClient, connection_
     href = connection_point_uri_format.format(site_id=1)
     new_cp_specified: ConnectionPointRequest = ConnectionPointRequest(id="1212121212")
     response = await client.post(
-        url=href, headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)}, content=new_cp_specified.to_xml()
+        url=href, headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)}, content=new_cp_specified.to_xml()
     )
     assert_response_header(response, HTTPStatus.CREATED, expected_content_type=None)
     body = read_response_body_string(response)
@@ -96,7 +96,7 @@ async def test_connectionpoint_update_and_fetch(client: AsyncClient, connection_
     assert len(body) == 0
 
     # check it updated
-    response = await client.get(href, headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)})
+    response = await client.get(href, headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)})
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
     assert len(body) > 0

--- a/tests/integration/func_sets/test_derp.py
+++ b/tests/integration/func_sets/test_derp.py
@@ -18,13 +18,13 @@ from envoy.server.schema.sep2.der import (
 from tests.assert_time import assert_datetime_equal
 from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as AGG_1_VALID_CERT
 from tests.data.certificates.certificate4 import TEST_CERTIFICATE_FINGERPRINT as AGG_2_VALID_CERT
-from tests.integration.integration_server import cert_pem_header
+from tests.integration.integration_server import cert_header
 from tests.integration.request import build_paging_params
 from tests.integration.response import assert_error_response, assert_response_header, read_response_body_string
 
 
 def generate_headers(cert: Any):
-    return {cert_pem_header: urllib.parse.quote(cert)}
+    return {cert_header: urllib.parse.quote(cert)}
 
 
 @pytest.fixture

--- a/tests/integration/func_sets/test_end_device.py
+++ b/tests/integration/func_sets/test_end_device.py
@@ -12,7 +12,7 @@ from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as
 from tests.data.certificates.certificate4 import TEST_CERTIFICATE_FINGERPRINT as AGG_2_VALID_CERT
 from tests.data.certificates.certificate5 import TEST_CERTIFICATE_FINGERPRINT as AGG_3_VALID_CERT
 from tests.data.fake.generator import generate_class_instance
-from tests.integration.integration_server import cert_pem_header
+from tests.integration.integration_server import cert_header
 from tests.integration.request import build_paging_params
 from tests.integration.response import (
     assert_error_response,
@@ -43,7 +43,7 @@ async def test_get_end_device_list_by_aggregator(
     """Simple test of a valid get for different aggregator certs - validates that the response looks like XML
     and that it contains the expected end device SFDI's associated with each aggregator"""
     response = await client.get(
-        edev_base_uri + build_paging_params(limit=100), headers={cert_pem_header: urllib.parse.quote(cert)}
+        edev_base_uri + build_paging_params(limit=100), headers={cert_header: urllib.parse.quote(cert)}
     )
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
@@ -92,7 +92,7 @@ async def test_get_end_device_list_pagination(
     client: AsyncClient, edev_base_uri: str, query_string: str, site_sfdis: list[str], expected_total: int, cert: str
 ):
     """Tests that pagination variables on the list endpoint are respected"""
-    response = await client.get(edev_base_uri + query_string, headers={cert_pem_header: urllib.parse.quote(cert)})
+    response = await client.get(edev_base_uri + query_string, headers={cert_header: urllib.parse.quote(cert)})
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
     assert len(body) > 0
@@ -112,7 +112,7 @@ async def test_get_enddevice(client: AsyncClient, edev_fetch_uri_format: str):
 
     # check fetching within aggregator
     uri = edev_fetch_uri_format.format(site_id=2)
-    response = await client.get(uri, headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)})
+    response = await client.get(uri, headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)})
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
     assert len(body) > 0
@@ -126,13 +126,13 @@ async def test_get_enddevice(client: AsyncClient, edev_fetch_uri_format: str):
 
     # check fetching outside aggregator
     uri = edev_fetch_uri_format.format(site_id=3)  # This belongs to agg2
-    response = await client.get(uri, headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)})
+    response = await client.get(uri, headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)})
     assert_response_header(response, HTTPStatus.NOT_FOUND)
     assert_error_response(response)
 
     # check fetching an ID that does not exist
     uri = edev_fetch_uri_format.format(site_id=9999)  # This does not exist
-    response = await client.get(uri, headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)})
+    response = await client.get(uri, headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)})
     assert_response_header(response, HTTPStatus.NOT_FOUND)
     assert_error_response(response)
 
@@ -145,7 +145,7 @@ async def test_create_end_device(client: AsyncClient, edev_base_uri: str):
     insert_request.deviceCategory = "{0:x}".format(int(DeviceCategory.HOT_TUB))
     response = await client.post(
         edev_base_uri,
-        headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)},
+        headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
         content=EndDeviceRequest.to_xml(insert_request),
     )
     assert_response_header(response, HTTPStatus.CREATED, expected_content_type=None)
@@ -153,7 +153,7 @@ async def test_create_end_device(client: AsyncClient, edev_base_uri: str):
     inserted_href = read_location_header(response)
 
     # now lets grab the end device we just created
-    response = await client.get(inserted_href, headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)})
+    response = await client.get(inserted_href, headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)})
     assert_response_header(response, HTTPStatus.OK)
     response_body = read_response_body_string(response)
     assert len(response_body) > 0
@@ -166,13 +166,13 @@ async def test_create_end_device(client: AsyncClient, edev_base_uri: str):
     assert parsed_response.deviceCategory == insert_request.deviceCategory
 
     # check that other aggregators can't fetch it
-    response = await client.get(inserted_href, headers={cert_pem_header: urllib.parse.quote(AGG_2_VALID_CERT)})
+    response = await client.get(inserted_href, headers={cert_header: urllib.parse.quote(AGG_2_VALID_CERT)})
     assert_response_header(response, HTTPStatus.NOT_FOUND)
     assert_error_response(response)
 
     # check the new end_device count for aggregator 1
     response = await client.get(
-        edev_base_uri + build_paging_params(limit=100), headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)}
+        edev_base_uri + build_paging_params(limit=100), headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)}
     )
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
@@ -193,7 +193,7 @@ async def test_update_end_device(client: AsyncClient, edev_base_uri: str):
     update_request.deviceCategory = updated_device_category  # update device category
     response = await client.post(
         edev_base_uri,
-        headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)},
+        headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
         content=EndDeviceRequest.to_xml(update_request),
     )
     assert_response_header(response, HTTPStatus.CREATED, expected_content_type=None)
@@ -202,7 +202,7 @@ async def test_update_end_device(client: AsyncClient, edev_base_uri: str):
     assert inserted_href.endswith("/1"), "Updating site 1"
 
     # now lets grab the end device we just updated
-    response = await client.get(inserted_href, headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)})
+    response = await client.get(inserted_href, headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)})
     assert_response_header(response, HTTPStatus.OK)
     response_body = read_response_body_string(response)
     assert len(response_body) > 0
@@ -220,14 +220,14 @@ async def test_update_end_device(client: AsyncClient, edev_base_uri: str):
     )  # update device category
     response = await client.post(
         edev_base_uri,
-        headers={cert_pem_header: urllib.parse.quote(AGG_2_VALID_CERT)},
+        headers={cert_header: urllib.parse.quote(AGG_2_VALID_CERT)},
         content=EndDeviceRequest.to_xml(update_request),
     )
     assert_response_header(response, HTTPStatus.CONFLICT)  # conflict because the LFDI isn't unique to this agg
     assert_error_response(response)
 
     # double check the deviceCategory is left alone
-    response = await client.get(inserted_href, headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)})
+    response = await client.get(inserted_href, headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)})
     assert_response_header(response, HTTPStatus.OK)
     response_body = read_response_body_string(response)
     assert len(response_body) > 0
@@ -241,7 +241,7 @@ async def test_update_end_device(client: AsyncClient, edev_base_uri: str):
 
     # check the new end_device count for aggregator 1
     response = await client.get(
-        edev_base_uri + build_paging_params(limit=100), headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)}
+        edev_base_uri + build_paging_params(limit=100), headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)}
     )
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
@@ -263,7 +263,7 @@ async def test_update_end_device_bad_device_category(
     update_request.deviceCategory = "efffffff"  # bad value
     response = await client.post(
         edev_base_uri,
-        headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)},
+        headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
         content=EndDeviceRequest.to_xml(update_request),
     )
     assert_response_header(response, HTTPStatus.BAD_REQUEST, expected_content_type=None)
@@ -271,7 +271,7 @@ async def test_update_end_device_bad_device_category(
 
     # double check the deviceCategory is left alone
     response = await client.get(
-        edev_fetch_uri_format.format(site_id=1), headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)}
+        edev_fetch_uri_format.format(site_id=1), headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)}
     )
     assert_response_header(response, HTTPStatus.OK)
     response_body = read_response_body_string(response)

--- a/tests/integration/func_sets/test_metering_mirror.py
+++ b/tests/integration/func_sets/test_metering_mirror.py
@@ -28,7 +28,7 @@ from tests.assert_time import assert_nowish
 from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as AGG_1_VALID_CERT
 from tests.data.certificates.certificate4 import TEST_CERTIFICATE_FINGERPRINT as AGG_2_VALID_CERT
 from tests.data.fake.generator import assert_class_instance_equality
-from tests.integration.integration_server import cert_pem_header
+from tests.integration.integration_server import cert_header
 from tests.integration.request import build_paging_params
 from tests.integration.response import assert_response_header, read_location_header, read_response_body_string
 from tests.postgres_testing import generate_async_session
@@ -74,7 +74,7 @@ async def test_get_mirror_usage_point_list_pagination(
     """Simple test of pagination of MUPs for a given aggregator"""
     response = await client.get(
         uris.MirrorUsagePointListUri + build_paging_params(limit=limit, start=start, changed_after=changed_after),
-        headers={cert_pem_header: urllib.parse.quote(cert)},
+        headers={cert_header: urllib.parse.quote(cert)},
     )
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
@@ -159,13 +159,13 @@ async def test_create_update_mup(client: AsyncClient, mup: MirrorUsagePointReque
     response = await client.post(
         uris.MirrorUsagePointListUri,
         content=MirrorUsagePointRequest.to_xml(mup, skip_empty=True),
-        headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)},
+        headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
     )
     assert_response_header(response, HTTPStatus.CREATED, expected_content_type=None)
     assert read_location_header(response) == expected_href
 
     # see if we can fetch the mup directly
-    response = await client.get(expected_href, headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)})
+    response = await client.get(expected_href, headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)})
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
     assert len(body) > 0
@@ -176,7 +176,7 @@ async def test_create_update_mup(client: AsyncClient, mup: MirrorUsagePointReque
     # see if the list endpoint can fetch it via the updated time
     response = await client.get(
         uris.MirrorUsagePointListUri + build_paging_params(limit=99, changed_after=now),
-        headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)},
+        headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
     )
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
@@ -213,7 +213,7 @@ async def test_submit_mirror_meter_reading(client: AsyncClient, pg_base_config):
     response = await client.post(
         uris.MirrorUsagePointUri.format(mup_id=mup_id),
         content=MirrorMeterReading.to_xml(mmr, skip_empty=True),
-        headers={cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)},
+        headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
     )
     assert_response_header(response, HTTPStatus.CREATED, expected_content_type=None)
 

--- a/tests/integration/func_sets/test_pricing.py
+++ b/tests/integration/func_sets/test_pricing.py
@@ -21,14 +21,14 @@ from envoy.server.schema.sep2.pricing import (
     TimeTariffIntervalResponse,
 )
 from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as AGG_1_VALID_CERT
-from tests.integration.integration_server import cert_pem_header
+from tests.integration.integration_server import cert_header
 from tests.integration.request import build_paging_params
 from tests.integration.response import assert_error_response, assert_response_header, read_response_body_string
 
 
 @pytest.fixture
 def agg_1_headers():
-    return {cert_pem_header: urllib.parse.quote(AGG_1_VALID_CERT)}
+    return {cert_header: urllib.parse.quote(AGG_1_VALID_CERT)}
 
 
 @pytest.mark.anyio

--- a/tests/integration/general/test_settings.py
+++ b/tests/integration/general/test_settings.py
@@ -1,0 +1,40 @@
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+from test_api import ALL_ENDPOINTS_WITH_SUPPORTED_METHODS
+
+from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as VALID_CERT
+from tests.integration.http import HTTPMethod
+from tests.integration.response import assert_response_header
+
+UPPERCASE_CERT_HEADER = "x-Header-With-UpperCASE"
+LOWERCASE_CERT_HEADER = "x-header-with-lower-case"
+
+GET_URIS = [(uri) for (valid_methods, uri) in ALL_ENDPOINTS_WITH_SUPPORTED_METHODS if HTTPMethod.GET in valid_methods]
+
+
+@pytest.mark.cert_header(UPPERCASE_CERT_HEADER)
+@pytest.mark.parametrize("uri", GET_URIS)
+@pytest.mark.anyio
+async def test_custom_cert_header_with_uppercase(uri: str, client: AsyncClient):
+    """Validates that changing the default setting for the cert_header to include uppercase values doesn't cause
+    problems (this is a regression test for catching a HTTP 500 spotted in a custom environment)"""
+    resp_case_match = await client.get(uri, headers={UPPERCASE_CERT_HEADER: VALID_CERT})
+    assert_response_header(resp_case_match, HTTPStatus.OK)
+
+    resp_case_mismatch = await client.get(uri, headers={UPPERCASE_CERT_HEADER.lower(): VALID_CERT})
+    assert_response_header(resp_case_mismatch, HTTPStatus.OK)
+
+
+@pytest.mark.cert_header(LOWERCASE_CERT_HEADER)
+@pytest.mark.parametrize("uri", GET_URIS)
+@pytest.mark.anyio
+async def test_custom_cert_header_with_lowercase(uri: str, client: AsyncClient):
+    """Validates that changing the default setting for the cert_header to include uppercase values doesn't cause
+    problems (this is a regression test for catching a HTTP 500 spotted in a custom environment)"""
+    resp_case_match = await client.get(uri, headers={LOWERCASE_CERT_HEADER: VALID_CERT})
+    assert_response_header(resp_case_match, HTTPStatus.OK)
+
+    resp_case_mismatch = await client.get(uri, headers={LOWERCASE_CERT_HEADER.upper(): VALID_CERT})
+    assert_response_header(resp_case_mismatch, HTTPStatus.OK)

--- a/tests/integration/integration_server.py
+++ b/tests/integration/integration_server.py
@@ -1,3 +1,3 @@
 from envoy.server.main import settings
 
-cert_pem_header = settings.cert_pem_header  # The "special" header that client certs should reference
+cert_header = settings.cert_header  # The "special" header that client certs should reference

--- a/tests/integration/response.py
+++ b/tests/integration/response.py
@@ -8,7 +8,7 @@ from envoy.server.schema.sep2.error import ErrorResponse
 from envoy.server.schema.sep2.types import ReasonCodeType
 from tests.data.certificates.certificate3 import TEST_CERTIFICATE_PEM as EXPIRED_PEM
 from tests.data.certificates.certificate_noreg import TEST_CERTIFICATE_PEM as UNKNOWN_PEM
-from tests.integration.integration_server import cert_pem_header
+from tests.integration.integration_server import cert_header
 
 
 def assert_response_header(
@@ -67,17 +67,17 @@ async def run_basic_unauthorised_tests(
     secured with our LFDI auth dependency"""
 
     # check expired certs don't work
-    response = await client.request(method=method, url=uri, content=body, headers={cert_pem_header: EXPIRED_PEM})
+    response = await client.request(method=method, url=uri, content=body, headers={cert_header: EXPIRED_PEM})
     assert_response_header(response, HTTPStatus.FORBIDDEN)
     assert_error_response(response)
 
     # check unregistered certs don't work
-    response = await client.request(method=method, url=uri, content=body, headers={cert_pem_header: UNKNOWN_PEM})
+    response = await client.request(method=method, url=uri, content=body, headers={cert_header: UNKNOWN_PEM})
     assert_response_header(response, HTTPStatus.FORBIDDEN)
     assert_error_response(response)
 
     # missing cert (register as 500 as the gateway should be handling this)
-    response = await client.request(method=method, url=uri, content=body, headers={cert_pem_header: ""})
+    response = await client.request(method=method, url=uri, content=body, headers={cert_header: ""})
     assert_response_header(response, HTTPStatus.FORBIDDEN)
     assert_error_response(response)
     response = await client.request(method=method, url=uri, content=body)
@@ -85,6 +85,6 @@ async def run_basic_unauthorised_tests(
     assert_error_response(response)
 
     # malformed cert
-    response = await client.request(method=method, url=uri, content=body, headers={cert_pem_header: "abc-123"})
+    response = await client.request(method=method, url=uri, content=body, headers={cert_header: "abc-123"})
     assert_response_header(response, HTTPStatus.FORBIDDEN)
     assert_error_response(response)

--- a/tests/unit/server/api/test_depends.py
+++ b/tests/unit/server/api/test_depends.py
@@ -19,7 +19,7 @@ from tests.data.certificates.certificate3 import TEST_CERTIFICATE_PEM as TEST_CE
 from tests.data.certificates.certificate4 import TEST_CERTIFICATE_FINGERPRINT as TEST_CERTIFICATE_FINGERPRINT_4
 from tests.data.certificates.certificate4 import TEST_CERTIFICATE_LFDI as TEST_CERTIFICATE_LFDI_4
 from tests.data.certificates.certificate4 import TEST_CERTIFICATE_PEM as TEST_CERTIFICATE_PEM_4
-from tests.integration.integration_server import cert_pem_header
+from tests.integration.integration_server import cert_header
 
 
 def test_generate_lfdi_from_fingerprint():
@@ -43,7 +43,7 @@ def test_generate_lfdi_from_pem():
 async def test_lfdiauthdepends_request_with_no_certpemheader_expect_500_response():
     req = Request({"type": "http", "headers": {}})
 
-    lfdi_dep = LFDIAuthDepends(settings.cert_pem_header)
+    lfdi_dep = LFDIAuthDepends(settings.cert_header)
 
     with pytest.raises(HTTPException) as exc:
         await lfdi_dep(req)
@@ -62,11 +62,11 @@ async def test_lfdiauthdepends_request_with_unregistered_cert_expect_403_respons
     req = Request(
         {
             "type": "http",
-            "headers": Headers({cert_pem_header: TEST_CERTIFICATE_PEM_1.decode("utf-8")}).raw,
+            "headers": Headers({cert_header: TEST_CERTIFICATE_PEM_1.decode("utf-8")}).raw,
         }
     )
 
-    lfdi_dep = LFDIAuthDepends(settings.cert_pem_header)
+    lfdi_dep = LFDIAuthDepends(settings.cert_header)
 
     # Act
 


### PR DESCRIPTION
The setting `cert_pem_header` is now accepting a cert fingerprint. Renamed to `cert_header`. Also fixed a bug where a value for `cert_header` containing uppercase characters would never match essentially locking down the server