### PR TITLE
Added support for both fingerprint and pem auth

### DIFF
--- a/src/envoy/server/settings.py
+++ b/src/envoy/server/settings.py
@@ -12,7 +12,7 @@ class AppSettings(BaseSettings):
     title: str = "envoy"
     version: str = "0.0.0"
 
-    cert_header: str = "x-forwarded-client-cert"
+    cert_header: str = "x-forwarded-client-cert"  # either client certificate in PEM format or the sha256 fingerprint
     default_timezone: str = "Australia/Brisbane"
 
     database_url: PostgresDsn

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,8 @@ from envoy.admin.main import generate_app as admin_gen_app
 from envoy.admin.settings import generate_settings as admin_gen_settings
 from envoy.server.main import generate_app
 from envoy.server.settings import generate_settings
-from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as VALID_CERT
+from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as VALID_CERT_FINGERPRINT
+from tests.data.certificates.certificate1 import TEST_CERTIFICATE_PEM as VALID_CERT_PEM
 from tests.integration.integration_server import cert_header
 
 
@@ -26,7 +27,12 @@ async def client(pg_base_config: Connection):
 
 @pytest.fixture
 def valid_headers():
-    return {cert_header: urllib.parse.quote(VALID_CERT)}
+    return {cert_header: VALID_CERT_PEM.decode()}
+
+
+@pytest.fixture
+def valid_headers_fingerprint():
+    return {cert_header: VALID_CERT_FINGERPRINT}
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/general/test_api.py
+++ b/tests/integration/general/test_api.py
@@ -83,6 +83,18 @@ async def test_resource_with_invalid_methods(
         assert_response_header(response, HTTPStatus.METHOD_NOT_ALLOWED, expected_content_type=None)
 
 
+@pytest.mark.parametrize("valid_methods,uri", ALL_ENDPOINTS_WITH_SUPPORTED_METHODS)
+@pytest.mark.anyio
+async def test_fingerprint_auth(
+    valid_methods: list[HTTPMethod], uri: str, client: AsyncClient, valid_headers_fingerprint: dict
+):
+    """Simple test to validate that using our fingerprint auth will work - just testing on GET methods
+    for simplicity. Other tests will validate that the PEM encoded certs work"""
+    if HTTPMethod.GET in valid_methods:
+        response = await client.request(method=HTTPMethod.GET.name, url=uri, headers=valid_headers_fingerprint)
+        assert_response_header(response, HTTPStatus.OK, expected_content_type=None)
+
+
 @pytest.mark.anyio
 async def test_crawl_hrefs(client: AsyncClient, valid_headers: dict):
     """Crawls through ALL_ENDPOINTS_WITH_SUPPORTED_METHODS - makes every get request

--- a/tests/unit/server/api/test_depends.py
+++ b/tests/unit/server/api/test_depends.py
@@ -69,11 +69,9 @@ async def test_lfdiauthdepends_request_with_unregistered_cert_expect_403_respons
     lfdi_dep = LFDIAuthDepends(settings.cert_header)
 
     # Act
-
     with pytest.raises(HTTPException) as exc:
         await lfdi_dep(req)
 
     # Assert
-
     assert exc.value.status_code == 403
     mock_select_client_ids_using_lfdi.assert_called_once()


### PR DESCRIPTION
Allows our cert_header to support EITHER a sha256 certificate fingerprint or a full client certificate in PEM format.

We've had demand for both and clients that want to swap between the two - easier to support both insitu