### PR TITLE
Added a status health check endpoint

### DIFF
--- a/src/envoy/server/api/__init__.py
+++ b/src/envoy/server/api/__init__.py
@@ -8,7 +8,10 @@ from envoy.server.api.sep2.function_set_assignments import router as fsa_router
 from envoy.server.api.sep2.metering_mirror import router as mm_router
 from envoy.server.api.sep2.pricing import router as price_router
 from envoy.server.api.sep2.time import router as tm_router
+from envoy.server.api.unsecured.health import router as health_router
 
 __all__ = ["routers"]
 
 routers = [cp_router, dcap_router, edev_router, derp_router, fsa_router, mm_router, price_router, tm_router]
+
+unsecured_routers = [health_router]

--- a/src/envoy/server/api/unsecured/__init__.py
+++ b/src/envoy/server/api/unsecured/__init__.py
@@ -1,0 +1,1 @@
+"""Routing specifically for endpoints without any authentication."""

--- a/src/envoy/server/api/unsecured/health.py
+++ b/src/envoy/server/api/unsecured/health.py
@@ -1,0 +1,39 @@
+import logging
+from http import HTTPStatus
+
+from fastapi import APIRouter, Response
+from fastapi_async_sqlalchemy import db
+
+from envoy.server.manager.health import HealthManager
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter()
+
+HEALTH_URI = "/status/health"
+
+
+@router.head(HEALTH_URI)
+@router.get(HEALTH_URI, status_code=HTTPStatus.OK)
+async def get_health() -> Response:
+    """Responds with a HTTP 200 if the server diagnostics report everything is OK. HTTP 500 otherwise.
+
+    Response will be a plaintext encoding of the passing/failing health checks
+
+    Returns:
+        fastapi.Response object.
+    """
+
+    check = await HealthManager.run_health_check(db.session)
+    headers = {"Content-Type": "text/plain"}
+    content = str(check)
+
+    if not check.database_connectivity:
+        status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    elif not check.database_has_data:
+        status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    else:
+        status_code = HTTPStatus.OK
+
+    return Response(content=content, status_code=status_code, headers=headers)

--- a/src/envoy/server/crud/health.py
+++ b/src/envoy/server/crud/health.py
@@ -1,0 +1,32 @@
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from envoy.server.model.aggregator import Aggregator
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HealthCheck:
+    """A snapshot of the envoy system health."""
+
+    database_connectivity: bool = False  # true if the database can be queried
+    database_has_data: bool = False  # true if the database has a basic configuration
+
+
+async def check_database(session: AsyncSession, check: HealthCheck) -> None:
+    """Checks the database connection and populates the results to check.
+
+    Any raised exceptions will be caught and logged."""
+    try:
+        stmt = select(func.count()).select_from(Aggregator)
+        resp = await session.execute(stmt)
+
+        check.database_connectivity = True
+        check.database_has_data = resp.scalar_one() > 0
+    except Exception as ex:
+        check.database_connectivity = False
+        logger.error(f"check_database: Exception checking database connectivity {ex}")

--- a/src/envoy/server/manager/health.py
+++ b/src/envoy/server/manager/health.py
@@ -1,0 +1,17 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from envoy.server.crud.health import HealthCheck, check_database
+
+
+class HealthManager:
+    @staticmethod
+    async def run_health_check(session: AsyncSession) -> HealthCheck:
+        """Runs all health checks for the server"""
+
+        # create a failing check
+        check = HealthCheck()
+
+        # run through every check setting it incrementally to non failing
+        await check_database(session, check)
+
+        return check

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,8 +16,9 @@ from tests.unit.jwt import generate_rs256_jwt
 
 
 @pytest.fixture
-async def client(pg_base_config: Connection):
-    """Creates an AsyncClient for a test that is configured to talk to the main server app"""
+async def client_empty_db(pg_empty_config: Connection):
+    """Creates an AsyncClient for a test that is configured to talk to the main server app (but the database
+    will have no data in it)"""
 
     # We want a new app instance for every test - otherwise connection pools get shared and we hit problems
     # when trying to run multiple tests sequentially
@@ -25,6 +26,12 @@ async def client(pg_base_config: Connection):
     async with LifespanManager(app):  # This ensures that startup events are fired when the app starts
         async with AsyncClient(app=app, base_url="http://test") as c:
             yield c
+
+
+@pytest.fixture
+async def client(pg_base_config: Connection, client_empty_db):
+    """Creates an AsyncClient for a test that is configured to talk to the main server app"""
+    yield client_empty_db
 
 
 @pytest.fixture

--- a/tests/integration/unsecured/__init__.py
+++ b/tests/integration/unsecured/__init__.py
@@ -1,0 +1,1 @@
+"""Top level organisational directory for all integration tests linked to unsecured endpoints"""

--- a/tests/integration/unsecured/test_health.py
+++ b/tests/integration/unsecured/test_health.py
@@ -1,0 +1,31 @@
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+from envoy.server.api.unsecured.health import HEALTH_URI
+from tests.integration.response import read_response_body_string
+
+
+@pytest.mark.anyio
+async def test_get_health_works_for_any_auth(client: AsyncClient, valid_headers):
+    """Checks HEALTH_URI returns HTTP 200 for all requests (ignoring auth)"""
+
+    # no login
+    response = await client.request(method="GET", url=HEALTH_URI)
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"
+
+    # valid login
+    response = await client.request(method="GET", url=HEALTH_URI, headers=valid_headers)
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
+async def test_get_health_detects_no_data(client_empty_db: AsyncClient):
+    """Checks the health check will fail if the DB is empty"""
+
+    response = await client_empty_db.request(method="GET", url=HEALTH_URI)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert read_response_body_string(response), "Expected a response with some content"

--- a/tests/unit/server/crud/test_health.py
+++ b/tests/unit/server/crud/test_health.py
@@ -1,0 +1,44 @@
+import unittest.mock as mock
+
+import pytest
+
+from envoy.server.crud.health import HealthCheck, check_database
+from tests.postgres_testing import generate_async_session
+
+
+def test_health_defaults():
+    check = HealthCheck()
+    assert not check.database_connectivity
+    assert not check.database_has_data
+
+
+@pytest.mark.anyio
+async def test_health_check_ok(pg_base_config):
+    """Tests that the health check returns OK on the basic database config"""
+    async with generate_async_session(pg_base_config) as session:
+        check = HealthCheck()
+        await check_database(session, check)
+        assert check.database_connectivity
+        assert check.database_has_data
+
+
+@pytest.mark.anyio
+async def test_health_check_no_data(pg_empty_config):
+    """Tests that the health check returns failure on the empty DB"""
+    async with generate_async_session(pg_empty_config) as session:
+        check = HealthCheck()
+        await check_database(session, check)
+        assert check.database_connectivity
+        assert not check.database_has_data
+
+
+@pytest.mark.anyio
+async def test_health_check_bad_db():
+    """Tests that causing the db checks to raise an exception correctly populates the check"""
+    check = HealthCheck()
+    session = mock.Mock()
+    session.execute = mock.Mock(side_effect=Exception("my mock error"))
+    await check_database(session, check)
+    assert not check.database_connectivity
+    assert not check.database_has_data
+    session.execute.assert_called_once()


### PR DESCRIPTION
Added a `/status/health` status health check endpoint that's unsecured and will allow third party tools to poll Envoy to check whether things look healthy or not.