### PR TITLE
Added price/doe health check endpoints

### DIFF
--- a/src/envoy/server/api/unsecured/health.py
+++ b/src/envoy/server/api/unsecured/health.py
@@ -13,6 +13,9 @@ router = APIRouter()
 
 HEALTH_URI = "/status/health"
 
+HEALTH_DOE_URI = "/status/doe"
+HEALTH_DYNAMIC_PRICE_URI = "/status/dynamicprices"
+
 
 @router.head(HEALTH_URI)
 @router.get(HEALTH_URI, status_code=HTTPStatus.OK)
@@ -32,6 +35,57 @@ async def get_health() -> Response:
     if not check.database_connectivity:
         status_code = HTTPStatus.INTERNAL_SERVER_ERROR
     elif not check.database_has_data:
+        status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    else:
+        status_code = HTTPStatus.OK
+
+    return Response(content=content, status_code=status_code, headers=headers)
+
+
+@router.head(HEALTH_DOE_URI)
+@router.get(HEALTH_DOE_URI, status_code=HTTPStatus.OK)
+async def get_doe_health() -> Response:
+    """Responds with a HTTP 200 if the server dynamic operating envelope diagnostics report everything is OK.
+    HTTP 500 otherwise.
+
+    Response will be a plaintext encoding of the passing/failing health checks
+
+    Returns:
+        fastapi.Response object.
+    """
+
+    check = await HealthManager.run_dynamic_operating_envelope_check(db.session)
+    headers = {"Content-Type": "text/plain"}
+    content = str(check)
+
+    if not check.has_does:
+        status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    elif not check.has_future_does:
+        status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    else:
+        status_code = HTTPStatus.OK
+
+    return Response(content=content, status_code=status_code, headers=headers)
+
+
+@router.head(HEALTH_DYNAMIC_PRICE_URI)
+@router.get(HEALTH_DYNAMIC_PRICE_URI, status_code=HTTPStatus.OK)
+async def get_dynamic_price_health() -> Response:
+    """Responds with a HTTP 200 if the server dynamic prices diagnostics report everything is OK. HTTP 500 otherwise.
+
+    Response will be a plaintext encoding of the passing/failing health checks
+
+    Returns:
+        fastapi.Response object.
+    """
+
+    check = await HealthManager.run_dynamic_price_check(db.session)
+    headers = {"Content-Type": "text/plain"}
+    content = str(check)
+
+    if not check.has_dynamic_prices:
+        status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    elif not check.has_future_prices:
         status_code = HTTPStatus.INTERNAL_SERVER_ERROR
     else:
         status_code = HTTPStatus.OK

--- a/src/envoy/server/crud/health.py
+++ b/src/envoy/server/crud/health.py
@@ -1,10 +1,13 @@
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from envoy.server.model.aggregator import Aggregator
+from envoy.server.model.doe import DynamicOperatingEnvelope
+from envoy.server.model.tariff import TariffGeneratedRate
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +18,22 @@ class HealthCheck:
 
     database_connectivity: bool = False  # true if the database can be queried
     database_has_data: bool = False  # true if the database has a basic configuration
+
+
+@dataclass
+class DynamicPriceCheck:
+    """A snapshot of the envoy system health."""
+
+    has_dynamic_prices: bool = False  # true if the database has at least 1 dynamic price
+    has_future_prices: bool = False  # true if the database has at least 1 dynamic price for upcoming time periods
+
+
+@dataclass
+class DynamicOperatingEnvelopeCheck:
+    """A snapshot of the envoy system health."""
+
+    has_does: bool = False  # true if the database has at least 1 dynamic operating envelope
+    has_future_does: bool = False  # true if the database has at least 1 dynamic operating envelope for a future time
 
 
 async def check_database(session: AsyncSession, check: HealthCheck) -> None:
@@ -30,3 +49,69 @@ async def check_database(session: AsyncSession, check: HealthCheck) -> None:
     except Exception as ex:
         check.database_connectivity = False
         logger.error(f"check_database: Exception checking database connectivity {ex}")
+
+
+async def check_dynamic_prices(session: AsyncSession, check: DynamicPriceCheck) -> None:
+    """Checks the stored dynamic prices and populates the results to check.
+
+    Any raised exceptions will be caught and logged."""
+    try:
+        # Look for the first entity whose start time exceeds now - look through more recent entries to hopefully get
+        # match more quickly
+        now = datetime.now(tz=timezone.utc)
+        future_rate_stmt = (
+            select(TariffGeneratedRate)
+            .where(TariffGeneratedRate.start_time >= now)
+            .order_by(TariffGeneratedRate.tariff_generated_rate_id.desc())
+            .limit(1)
+        )
+        future_rate_resp = await session.execute(future_rate_stmt)
+
+        future_rate = future_rate_resp.one_or_none()
+        if future_rate is not None:
+            check.has_dynamic_prices = True
+            check.has_future_prices = True
+            return
+
+        # At this point there's nothing in the future - but maybe we have historical data
+        check.has_future_prices = False
+        count_rate_stmt = select(func.count()).select_from(TariffGeneratedRate)
+        count_rate_resp = await session.execute(count_rate_stmt)
+        check.has_dynamic_prices = count_rate_resp.scalar_one() > 0
+    except Exception as ex:
+        check.has_dynamic_prices = False
+        check.has_future_prices = False
+        logger.error(f"check_dynamic_prices: Exception checking database for rates {ex}")
+
+
+async def check_dynamic_operating_envelopes(session: AsyncSession, check: DynamicOperatingEnvelopeCheck) -> None:
+    """Checks the stored dynamic operating envelopes and populates the results to check.
+
+    Any raised exceptions will be caught and logged."""
+    try:
+        # Look for the first entity whose start time exceeds now - look through more recent entries to hopefully get
+        # match more quickly
+        now = datetime.now(tz=timezone.utc)
+        future_doe_stmt = (
+            select(DynamicOperatingEnvelope)
+            .where(DynamicOperatingEnvelope.start_time >= now)
+            .order_by(DynamicOperatingEnvelope.dynamic_operating_envelope_id.desc())
+            .limit(1)
+        )
+        future_rate_resp = await session.execute(future_doe_stmt)
+
+        future_rate = future_rate_resp.one_or_none()
+        if future_rate is not None:
+            check.has_does = True
+            check.has_future_does = True
+            return
+
+        # At this point there's nothing in the future - but maybe we have historical data
+        check.has_future_does = False
+        count_doe_stmt = select(func.count()).select_from(DynamicOperatingEnvelope)
+        count_rate_resp = await session.execute(count_doe_stmt)
+        check.has_does = count_rate_resp.scalar_one() > 0
+    except Exception as ex:
+        check.has_does = False
+        check.has_future_does = False
+        logger.error(f"check_dynamic_prices: Exception checking database for rates {ex}")

--- a/src/envoy/server/manager/health.py
+++ b/src/envoy/server/manager/health.py
@@ -1,6 +1,13 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from envoy.server.crud.health import HealthCheck, check_database
+from envoy.server.crud.health import (
+    DynamicOperatingEnvelopeCheck,
+    DynamicPriceCheck,
+    HealthCheck,
+    check_database,
+    check_dynamic_operating_envelopes,
+    check_dynamic_prices,
+)
 
 
 class HealthManager:
@@ -13,5 +20,26 @@ class HealthManager:
 
         # run through every check setting it incrementally to non failing
         await check_database(session, check)
+        return check
 
+    @staticmethod
+    async def run_dynamic_price_check(session: AsyncSession) -> DynamicPriceCheck:
+        """Runs all dynamic price checks for the server"""
+
+        # create a failing check
+        check = DynamicPriceCheck()
+
+        # run through every check setting it incrementally to non failing
+        await check_dynamic_prices(session, check)
+        return check
+
+    @staticmethod
+    async def run_dynamic_operating_envelope_check(session: AsyncSession) -> DynamicOperatingEnvelopeCheck:
+        """Runs all dynamic operating envelope checks for the server"""
+
+        # create a failing check
+        check = DynamicOperatingEnvelopeCheck()
+
+        # run through every check setting it incrementally to non failing
+        await check_dynamic_operating_envelopes(session, check)
         return check

--- a/tests/integration/unsecured/test_health.py
+++ b/tests/integration/unsecured/test_health.py
@@ -1,10 +1,15 @@
+from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 
-from envoy.server.api.unsecured.health import HEALTH_URI
+from envoy.server.api.unsecured.health import HEALTH_DOE_URI, HEALTH_DYNAMIC_PRICE_URI, HEALTH_URI
+from envoy.server.model.doe import DynamicOperatingEnvelope
+from envoy.server.model.tariff import TariffGeneratedRate
 from tests.integration.response import read_response_body_string
+from tests.postgres_testing import generate_async_session
 
 
 @pytest.mark.anyio
@@ -28,4 +33,72 @@ async def test_get_health_detects_no_data(client_empty_db: AsyncClient):
 
     response = await client_empty_db.request(method="GET", url=HEALTH_URI)
     assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
+async def test_get_price_health_fails_no_future_prices(client: AsyncClient):
+    """Checks HEALTH_DYNAMIC_PRICE_URI returns HTTP 500 if there are no future prices (the default for
+    pg_base_config)"""
+
+    response = await client.request(method="GET", url=HEALTH_DYNAMIC_PRICE_URI)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
+async def test_get_price_health_works_for_any_auth(client: AsyncClient, pg_base_config, valid_headers):
+    """Checks HEALTH_DYNAMIC_PRICE_URI returns HTTP 200 for all requests (ignoring auth)"""
+
+    # Update start time so we have a future price
+    now = datetime.now(tz=timezone.utc)
+    async with generate_async_session(pg_base_config) as session:
+        stmt = select(TariffGeneratedRate).where(TariffGeneratedRate.tariff_generated_rate_id == 4)
+        resp = await session.execute(stmt)
+        rate: TariffGeneratedRate = resp.scalar_one()
+        rate.start_time = now + timedelta(seconds=102)
+        await session.commit()
+
+    # no login
+    response = await client.request(method="GET", url=HEALTH_DYNAMIC_PRICE_URI)
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"
+
+    # valid login
+    response = await client.request(method="GET", url=HEALTH_DYNAMIC_PRICE_URI, headers=valid_headers)
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
+async def test_get_doe_health_fails_no_future_does(client: AsyncClient):
+    """Checks HEALTH_DOE_URI returns HTTP 500 if there are no future does (the default for
+    pg_base_config)"""
+
+    response = await client.request(method="GET", url=HEALTH_DOE_URI)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
+async def test_get_doe_health_works_for_any_auth(client: AsyncClient, pg_base_config, valid_headers):
+    """Checks HEALTH_DOE_URI returns HTTP 200 for all requests (ignoring auth)"""
+
+    # Update start time so we have a future price
+    now = datetime.now(tz=timezone.utc)
+    async with generate_async_session(pg_base_config) as session:
+        stmt = select(DynamicOperatingEnvelope).where(DynamicOperatingEnvelope.dynamic_operating_envelope_id == 2)
+        resp = await session.execute(stmt)
+        doe: DynamicOperatingEnvelope = resp.scalar_one()
+        doe.start_time = now + timedelta(seconds=103)
+        await session.commit()
+
+    # no login
+    response = await client.request(method="GET", url=HEALTH_DOE_URI)
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"
+
+    # valid login
+    response = await client.request(method="GET", url=HEALTH_DOE_URI, headers=valid_headers)
+    assert response.status_code == HTTPStatus.OK
     assert read_response_body_string(response), "Expected a response with some content"

--- a/tests/unit/server/crud/test_health.py
+++ b/tests/unit/server/crud/test_health.py
@@ -1,8 +1,19 @@
 import unittest.mock as mock
+from datetime import datetime, timedelta, timezone
 
 import pytest
+from sqlalchemy import select
 
-from envoy.server.crud.health import HealthCheck, check_database
+from envoy.server.crud.health import (
+    DynamicOperatingEnvelopeCheck,
+    DynamicPriceCheck,
+    HealthCheck,
+    check_database,
+    check_dynamic_operating_envelopes,
+    check_dynamic_prices,
+)
+from envoy.server.model.doe import DynamicOperatingEnvelope
+from envoy.server.model.tariff import TariffGeneratedRate
 from tests.postgres_testing import generate_async_session
 
 
@@ -42,3 +53,83 @@ async def test_health_check_bad_db():
     assert not check.database_connectivity
     assert not check.database_has_data
     session.execute.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_health_doe_check_no_data(pg_empty_config):
+    """Tests that the doe health check returns failure on the empty DB"""
+    async with generate_async_session(pg_empty_config) as session:
+        check = DynamicOperatingEnvelopeCheck()
+        await check_dynamic_operating_envelopes(session, check)
+        assert not check.has_does
+        assert not check.has_future_does
+
+
+@pytest.mark.anyio
+async def test_health_doe_check_no_future_does(pg_base_config):
+    """Tests that the doe health check returns failure if there are no future DOEs"""
+    async with generate_async_session(pg_base_config) as session:
+        check = DynamicOperatingEnvelopeCheck()
+        await check_dynamic_operating_envelopes(session, check)
+        assert check.has_does
+        assert not check.has_future_does
+
+
+@pytest.mark.anyio
+async def test_health_doe_check_with_future_does(pg_base_config):
+    """Tests that the doe health check returns failure if there are no future DOEs"""
+
+    # Update start time so we have a future DOE
+    now = datetime.now(tz=timezone.utc)
+    async with generate_async_session(pg_base_config) as session:
+        stmt = select(DynamicOperatingEnvelope).where(DynamicOperatingEnvelope.dynamic_operating_envelope_id == 3)
+        resp = await session.execute(stmt)
+        doe: DynamicOperatingEnvelope = resp.scalar_one()
+        doe.start_time = now + timedelta(seconds=100)
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        check = DynamicOperatingEnvelopeCheck()
+        await check_dynamic_operating_envelopes(session, check)
+        assert check.has_does
+        assert check.has_future_does
+
+
+@pytest.mark.anyio
+async def test_health_price_check_no_data(pg_empty_config):
+    """Tests that the price health check returns failure on the empty DB"""
+    async with generate_async_session(pg_empty_config) as session:
+        check = DynamicPriceCheck()
+        await check_dynamic_prices(session, check)
+        assert not check.has_dynamic_prices
+        assert not check.has_future_prices
+
+
+@pytest.mark.anyio
+async def test_health_price_check_no_future_prices(pg_base_config):
+    """Tests that the price health check returns failure if there are no future prices"""
+    async with generate_async_session(pg_base_config) as session:
+        check = DynamicPriceCheck()
+        await check_dynamic_prices(session, check)
+        assert check.has_dynamic_prices
+        assert not check.has_future_prices
+
+
+@pytest.mark.anyio
+async def test_health_price_check_with_future_prices(pg_base_config):
+    """Tests that the price health check returns failure if there are no future prices"""
+
+    # Update start time so we have a future price
+    now = datetime.now(tz=timezone.utc)
+    async with generate_async_session(pg_base_config) as session:
+        stmt = select(TariffGeneratedRate).where(TariffGeneratedRate.tariff_generated_rate_id == 4)
+        resp = await session.execute(stmt)
+        rate: TariffGeneratedRate = resp.scalar_one()
+        rate.start_time = now + timedelta(seconds=101)
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        check = DynamicPriceCheck()
+        await check_dynamic_prices(session, check)
+        assert check.has_dynamic_prices
+        assert check.has_future_prices


### PR DESCRIPTION
Added two new health checks - one for testing if we have current DOE's and one for if we have current dynamic prices.

It will allow external monitoring to capture if the downstream tools are generating prices/does or not.