### PR TITLE
add post decorator for DER-Settings/Status/Capability/Availability - …

### DIFF
--- a/src/envoy/server/api/sep2/der.py
+++ b/src/envoy/server/api/sep2/der.py
@@ -120,6 +120,8 @@ async def get_der_availability(request: Request, site_id: int, der_id: int) -> R
     return XmlResponse(result)
 
 
+# (temporary) see github issue: https://github.com/bsgip/envoy/issues/110
+@router.post(uri.DERAvailabilityUri, status_code=HTTPStatus.NO_CONTENT)
 @router.put(uri.DERAvailabilityUri, status_code=HTTPStatus.NO_CONTENT)
 async def put_der_availability(
     request: Request,
@@ -177,6 +179,8 @@ async def get_der_capability(request: Request, site_id: int, der_id: int) -> Res
     return XmlResponse(result)
 
 
+# (temporary) see github issue: https://github.com/bsgip/envoy/issues/110
+@router.post(uri.DERCapabilityUri, status_code=HTTPStatus.NO_CONTENT)
 @router.put(uri.DERCapabilityUri, status_code=HTTPStatus.NO_CONTENT)
 async def put_der_capability(
     request: Request,
@@ -234,6 +238,8 @@ async def get_der_status(request: Request, site_id: int, der_id: int) -> Respons
     return XmlResponse(result)
 
 
+# (temporary) see github issue: https://github.com/bsgip/envoy/issues/110
+@router.post(uri.DERStatusUri, status_code=HTTPStatus.NO_CONTENT)
 @router.put(uri.DERStatusUri, status_code=HTTPStatus.NO_CONTENT)
 async def put_der_status(
     request: Request,
@@ -291,6 +297,8 @@ async def get_der_settings(request: Request, site_id: int, der_id: int) -> Respo
     return XmlResponse(result)
 
 
+# (temporary) see github issue: https://github.com/bsgip/envoy/issues/110
+@router.post(uri.DERSettingsUri, status_code=HTTPStatus.NO_CONTENT)
 @router.put(uri.DERSettingsUri, status_code=HTTPStatus.NO_CONTENT)
 async def put_der_settings(
     request: Request,

--- a/tests/integration/general/test_api.py
+++ b/tests/integration/general/test_api.py
@@ -74,10 +74,10 @@ ALL_ENDPOINTS_WITH_SUPPORTED_METHODS: list[tuple[list[HTTPMethod], str]] = [
     # der function set
     ([HTTPMethod.GET, HTTPMethod.HEAD], "/edev/1/der"),
     ([HTTPMethod.GET, HTTPMethod.HEAD], "/edev/1/der/1"),
-    ([HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.PUT], "/edev/1/der/1/dera"),
-    ([HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.PUT], "/edev/1/der/1/dercap"),
-    ([HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.PUT], "/edev/1/der/1/derg"),
-    ([HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.PUT], "/edev/1/der/1/ders"),
+    ([HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.PUT, HTTPMethod.POST], "/edev/1/der/1/dera"),
+    ([HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.PUT, HTTPMethod.POST], "/edev/1/der/1/dercap"),
+    ([HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.PUT, HTTPMethod.POST], "/edev/1/der/1/derg"),
+    ([HTTPMethod.GET, HTTPMethod.HEAD, HTTPMethod.PUT, HTTPMethod.POST], "/edev/1/der/1/ders"),
 ]
 # fmt: on
 


### PR DESCRIPTION
Include POST endpoint (alongside the currently implemented PUT) for DER-Settings/Status/Capability/Availability to match CSIP-Aus test procedure.
**NB.** This is in conflict with base 2030.5 definition and should be raised to CSIP-Aus committee for review (it is likely a mistake). 