### PR TITLE
Billing report data aggregates multiphase readings

### DIFF
--- a/tests/unit/admin/mapper/test_billing.py
+++ b/tests/unit/admin/mapper/test_billing.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 
 import pytest
 from assertical.asserts.generator import assert_class_instance_equality
+from assertical.asserts.type import assert_list_type
 from assertical.fake.generator import generate_class_instance
 from envoy_schema.admin.schema.billing import (
     AggregatorBillingResponse,
@@ -46,6 +47,93 @@ def test_map_reading_value_power_of_ten(value: int, power_of_ten: int, expected_
     assert mapped.site_id == reading.site_reading_type.site_id
     assert mapped.period_start == reading.time_period_start
     assert mapped.duration_seconds == reading.time_period_seconds
+
+
+TS_1 = datetime(2023, 1, 1, 1, 1, 1)
+TS_2 = datetime(2023, 2, 2, 2, 2, 2)
+
+
+@pytest.mark.parametrize(
+    "expected_inputs, expected_outputs",
+    [
+        ([], []),  # Empty list
+        ([(1, TS_1, 100, -1)], [(1, TS_1, Decimal("1000"))]),  # Singleton
+        (
+            [(1, TS_1, 100, -1), (1, TS_2, 100, 0)],
+            [(1, TS_1, Decimal("1000")), (1, TS_2, Decimal("100"))],
+        ),  # Multiple, no aggregation, variation on timestamp
+        (
+            [(1, TS_1, 1, 0), (2, TS_1, 2, 0)],
+            [(1, TS_1, Decimal("1")), (2, TS_1, Decimal("2"))],
+        ),  # Multiple, no aggregation, variation on site
+        (
+            [
+                (1, TS_1, 1, 1),
+                (1, TS_1, 2, 2),
+                (1, TS_1, 3, 3),
+            ],
+            [(1, TS_1, Decimal("0.123"))],
+        ),  # Multiple, aggregate everything
+        (
+            [
+                (1, TS_1, 1, 1),
+                (1, TS_1, 2, 2),
+                (1, TS_1, 3, 3),
+                (1, TS_2, 4, 4),
+            ],
+            [(1, TS_1, Decimal("0.123")), (1, TS_2, Decimal("0.0004"))],
+        ),  # Multiple, some aggregation, finishing on non aggregate value
+        (
+            [
+                (1, TS_1, 4, -4),
+                (1, TS_2, 1, -1),
+                (1, TS_2, 2, -2),
+                (1, TS_2, 3, -3),
+            ],
+            [(1, TS_1, Decimal("40000")), (1, TS_2, Decimal("3210"))],
+        ),  # Multiple, some aggregation, finishing on aggregate value
+        (
+            [
+                (1, TS_1, 1, 0),
+                (1, TS_1, 2, 0),
+                (1, TS_2, 3, 0),
+                (1, TS_2, 4, 0),
+                (2, TS_1, 5, 0),
+                (2, TS_2, 6, 0),
+                (2, TS_2, 7, 0),
+            ],
+            [(1, TS_1, Decimal("3")), (1, TS_2, Decimal("7")), (2, TS_1, Decimal("5")), (2, TS_2, Decimal("13"))],
+        ),  # Multiple aggregations
+    ],
+)
+def test_aggregate_readings_for_site_timestamp(
+    expected_inputs: tuple[int, datetime, int, int], expected_outputs: tuple[int, datetime, Decimal]
+):
+    """Tests aggregate_readings_for_site_timestamp using a shorthand definition for input/output readings"""
+    duration_seconds = 54123
+
+    # Convert our simplified input data into real input site_readings
+    input_site_readings: list[SiteReading] = []
+    for site_id, time_period_start, value_int, pow10 in expected_inputs:
+        sr: SiteReading = generate_class_instance(SiteReading, generate_relationships=True)
+        sr.site_reading_type.site_id = site_id
+        sr.site_reading_type.power_of_ten_multiplier = pow10
+        sr.time_period_seconds = duration_seconds
+        sr.time_period_start = time_period_start
+        sr.value = value_int
+
+        input_site_readings.append(sr)
+
+    actual = list(BillingMapper.aggregate_readings_for_site_timestamp(input_site_readings))
+    assert_list_type(BillingReading, actual, len(expected_outputs))
+
+    # Validate that the returned values aggregate in the expected way
+    for tuple_vals, actual_billing_report in zip(expected_outputs, actual):
+        site_id, time_period_start, value = tuple_vals
+        expected_billing_report = BillingReading(
+            site_id=site_id, period_start=time_period_start, duration_seconds=duration_seconds, value=value
+        )
+        assert_class_instance_equality(BillingReading, expected_billing_report, actual_billing_report)
 
 
 @pytest.mark.parametrize(
@@ -114,10 +202,12 @@ def test_map_to_aggregator_response(optional_is_none: bool):
     assert mapped.aggregator_name == agg.name
     assert mapped.aggregator_id == agg.aggregator_id
     assert mapped.tariff_id == tariff_id
-    assert len(mapped.varh_readings) == 1
-    assert len(mapped.wh_readings) == 1
-    assert len(mapped.active_does) == 1
-    assert len(mapped.active_tariffs) == 1
+
+    assert_list_type(BillingReading, mapped.varh_readings, 1)
+    assert_list_type(BillingReading, mapped.wh_readings, 1)
+    assert_list_type(BillingReading, mapped.watt_readings, 1)
+    assert_list_type(BillingDoe, mapped.active_does, 1)
+    assert_list_type(BillingTariffRate, mapped.active_tariffs, 1)
 
     # This isn't meant to be exhaustive - the other tests will cover that - this will just ensure
     # the wh readings to go the wh list etc.
@@ -161,10 +251,11 @@ def test_map_to_sites_response(optional_is_none: bool):
     assert mapped.period_start == period_start
     assert mapped.period_end == period_end
     assert mapped.tariff_id == tariff_id
-    assert len(mapped.varh_readings) == 1
-    assert len(mapped.wh_readings) == 1
-    assert len(mapped.active_does) == 1
-    assert len(mapped.active_tariffs) == 1
+    assert_list_type(BillingReading, mapped.varh_readings, 1)
+    assert_list_type(BillingReading, mapped.wh_readings, 1)
+    assert_list_type(BillingReading, mapped.watt_readings, 1)
+    assert_list_type(BillingDoe, mapped.active_does, 1)
+    assert_list_type(BillingTariffRate, mapped.active_tariffs, 1)
 
     # This isn't meant to be exhaustive - the other tests will cover that - this will just ensure
     # the wh readings to go the wh list etc.
@@ -204,10 +295,11 @@ def test_map_to_calculation_log_response(optional_is_none: bool):
     assert isinstance(mapped, CalculationLogBillingResponse)
     assert mapped.calculation_log_id == log.calculation_log_id
     assert mapped.tariff_id == tariff_id
-    assert len(mapped.varh_readings) == 1
-    assert len(mapped.wh_readings) == 1
-    assert len(mapped.active_does) == 1
-    assert len(mapped.active_tariffs) == 1
+    assert_list_type(BillingReading, mapped.varh_readings, 1)
+    assert_list_type(BillingReading, mapped.wh_readings, 1)
+    assert_list_type(BillingReading, mapped.watt_readings, 1)
+    assert_list_type(BillingDoe, mapped.active_does, 1)
+    assert_list_type(BillingTariffRate, mapped.active_tariffs, 1)
 
     # This isn't meant to be exhaustive - the other tests will cover that - this will just ensure
     # the wh readings to go the wh list etc.


### PR DESCRIPTION
Billing report data will now aggregate multiphase readings into a single BillingReading via the admin server.

Eg - If a 3 phase site has a reading of 1, 2 and 3 for the various phases (at the same timestamp), this change will ensure the resulting Billing data will return a single BillingReading of value 6. Originally it returned 3 readings of values 1,2,3 which caused issues with downstream reports expecting a unique timestamp/site value.