### PR TITLE
Made billing endpoints better aggregate different quality readings

### DIFF
--- a/src/envoy/admin/mapper/billing.py
+++ b/src/envoy/admin/mapper/billing.py
@@ -10,12 +10,13 @@ from envoy_schema.admin.schema.billing import (
     CalculationLogBillingResponse,
     SiteBillingResponse,
 )
+from envoy_schema.server.schema.sep2.types import AccumulationBehaviourType, DataQualifierType, FlowDirectionType
 
 from envoy.admin.crud.billing import BillingData
 from envoy.server.model.aggregator import Aggregator
 from envoy.server.model.doe import DynamicOperatingEnvelope
 from envoy.server.model.log import CalculationLog
-from envoy.server.model.site_reading import SiteReading
+from envoy.server.model.site_reading import SiteReading, SiteReadingType
 from envoy.server.model.tariff import TariffGeneratedRate
 
 
@@ -23,7 +24,14 @@ class BillingMapper:
     @staticmethod
     def map_reading(reading: SiteReading) -> BillingReading:
         power = Decimal("10") ** -reading.site_reading_type.power_of_ten_multiplier
-        value = Decimal(reading.value) * power
+
+        # If the reading is from the perspective of a client EXPORTING into the grid, we need to flip the sign
+        # to align with our internal interpretation of +'ve meaning import and -'ve meaning export
+        sign: int = 1
+        if reading.site_reading_type.flow_direction == FlowDirectionType.REVERSE:
+            sign = -1
+        value = Decimal(reading.value) * power * sign
+
         return BillingReading(
             site_id=reading.site_reading_type.site_id,
             period_start=reading.time_period_start,
@@ -32,38 +40,122 @@ class BillingMapper:
         )
 
     @staticmethod
+    def reading_type_to_billing_primacy(srt: SiteReadingType) -> int:
+        """Given a SiteReadingType - generate a primacy (integer) that represents the 'quality' of reading type for
+        use with billing data. Higher primacy indicates higher 'quality'
+
+        Eg - MEAN Readings will be preferred over Instantaneous Readings which will be preferred over MIN/MAX readings
+        """
+
+        # Remember - Higher primacy equals higher quality
+        # Accumulation Behavior is our "secondary" consideration (i.e tiebreaker)
+        secondary_index = 0
+        if srt.accumulation_behaviour == AccumulationBehaviourType.NOT_APPLICABLE:
+            secondary_index = 0  # LOWEST PRIORITY/PRIMACY
+        elif srt.accumulation_behaviour == AccumulationBehaviourType.CUMULATIVE:
+            secondary_index = 1
+        elif srt.accumulation_behaviour == AccumulationBehaviourType.INDICATING:
+            secondary_index = 2
+        elif srt.accumulation_behaviour == AccumulationBehaviourType.INSTANTANEOUS:
+            secondary_index = 3
+        elif srt.accumulation_behaviour == AccumulationBehaviourType.DELTA_DATA:
+            secondary_index = 4
+        elif srt.accumulation_behaviour == AccumulationBehaviourType.SUMMATION:
+            secondary_index = 5  # HIGHEST PRIORITY/PRIMACY
+        else:
+            raise Exception(f"Unexpected accumulation behaviour: {srt.accumulation_behaviour}")
+
+        primary_index = 0
+        if srt.data_qualifier == DataQualifierType.NOT_APPLICABLE:
+            primary_index = 100  # LOWEST PRIORITY/PRIMACY
+        elif srt.data_qualifier == DataQualifierType.STANDARD:
+            primary_index = 200
+        elif srt.data_qualifier == DataQualifierType.STD_DEVIATION_OF_POPULATION:
+            primary_index = 300
+        elif srt.data_qualifier == DataQualifierType.STD_DEVIATION_OF_SAMPLE:
+            primary_index = 400
+        elif srt.data_qualifier == DataQualifierType.MINIMUM:
+            primary_index = 500
+        elif srt.data_qualifier == DataQualifierType.MAXIMUM:
+            primary_index = 600
+        elif srt.data_qualifier == DataQualifierType.AVERAGE:
+            primary_index = 700  # HIGHEST PRIORITY/PRIMACY
+        else:
+            raise Exception(f"Unexpected data qualifier: {srt.data_qualifier}")
+
+        return primary_index + secondary_index
+
+    @staticmethod
+    def choose_best_billing_readings(readings: Iterable[SiteReading]) -> list[SiteReading]:
+        """Given a stream of readings that all represent the same interval/site/type, pick the subset
+        of readings that represent the highest quality billing data.
+
+        NOTE: Expects readings to all have the same site_id/timestamp/uom
+
+        Eg - Given a set of Active Power Readings for Time X and Site Y - return the reading(s) that have the highest
+        values returned by reading_type_to_billing_primacy:"""
+        best_primacy = -1
+        best_readings = []
+
+        for reading in readings:
+            primacy = BillingMapper.reading_type_to_billing_primacy(reading.site_reading_type)
+            if primacy < best_primacy:
+                continue
+            elif primacy == best_primacy:
+                best_readings.append(reading)
+            else:
+                best_readings.clear()
+                best_primacy = primacy
+                best_readings.append(reading)
+
+        return best_readings
+
+    @staticmethod
     def aggregate_readings_for_site_timestamp(readings: Iterable[SiteReading]) -> Generator[BillingReading, None, None]:
-        """Given an incoming stream of readings, aggregate any readings that coincide with eachother by adding them.
+        """Given an incoming stream of readings, aggregate any readings that coincide with eachother by first filtering
+        with choose_best_billing_readings and then adding their values together.
 
         NOTE: Expects readings to be sorted on site_id/timestamp - unsorted lists will fail to aggregate correctly
 
-        The final result is a set of readings that have had their phasing info added together"""
+        The final result is a set of readings that have had their phasing info added together."""
+
+        def combine_readings_to_billing_reading(readings: Iterable[SiteReading]) -> Optional[BillingReading]:
+            combined_reading: Optional[BillingReading] = None
+            for reading in readings:
+                if combined_reading:
+                    combined_reading.value += BillingMapper.map_reading(reading).value
+                else:
+                    combined_reading = BillingMapper.map_reading(reading)
+            return combined_reading
 
         last_key: tuple[int, datetime] = (-1, datetime.min)
-        last_reading: Optional[BillingReading] = None
+        last_key_readings: list[SiteReading] = []
         for next_reading in readings:
             next_key = (next_reading.site_reading_type.site_id, next_reading.time_period_start)
-            mapped_next_reading = BillingMapper.map_reading(next_reading)
 
             if next_key == last_key:
-                # If our key matches the previously iterated reading, we roll this reading data into the previous value
-                # and then continue looking
-                if last_reading is None:
-                    raise Exception(f"key {next_key} matched {last_key} but last_reading is None.")  # Shouldn't happen
-
-                last_reading.value += mapped_next_reading.value
+                # If our key matches the previously iterated reading, we aim to roll this reading data into the
+                # previous readings and then continue looking
+                last_key_readings.append(next_reading)
                 continue
             else:
-                # In this case, we are done rolling values into the previous value and can return it
-                if last_reading is not None:
-                    yield last_reading
+                # In this case, we are done accumulating readings for the previous key. We can return the aggregated val
+                billing_reading = combine_readings_to_billing_reading(
+                    BillingMapper.choose_best_billing_readings(last_key_readings)
+                )
+                if billing_reading:
+                    yield billing_reading
 
-                last_reading = mapped_next_reading
+                last_key_readings.clear()
+                last_key_readings.append(next_reading)
                 last_key = next_key
 
-        # once we are done - return the last reading we were aggregating
-        if last_reading is not None:
-            yield last_reading
+        # once we are done - combine the remaining readings we were aggregating
+        billing_reading = combine_readings_to_billing_reading(
+            BillingMapper.choose_best_billing_readings(last_key_readings)
+        )
+        if billing_reading:
+            yield billing_reading
 
     @staticmethod
     def map_doe(doe: DynamicOperatingEnvelope) -> BillingDoe:

--- a/tests/unit/admin/mapper/test_billing.py
+++ b/tests/unit/admin/mapper/test_billing.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 import pytest
 from assertical.asserts.generator import assert_class_instance_equality
 from assertical.asserts.type import assert_list_type
-from assertical.fake.generator import generate_class_instance
+from assertical.fake.generator import clone_class_instance, generate_class_instance
 from envoy_schema.admin.schema.billing import (
     AggregatorBillingResponse,
     BillingDoe,
@@ -13,32 +13,41 @@ from envoy_schema.admin.schema.billing import (
     CalculationLogBillingResponse,
     SiteBillingResponse,
 )
+from envoy_schema.server.schema.sep2.types import AccumulationBehaviourType, DataQualifierType, FlowDirectionType
 
 from envoy.admin.crud.billing import BillingData
 from envoy.admin.mapper.billing import BillingMapper
 from envoy.server.model.aggregator import Aggregator
 from envoy.server.model.doe import DynamicOperatingEnvelope
 from envoy.server.model.log import CalculationLog
-from envoy.server.model.site_reading import SiteReading
+from envoy.server.model.site_reading import SiteReading, SiteReadingType
 from envoy.server.model.tariff import TariffGeneratedRate
 
 
 @pytest.mark.parametrize(
-    "value, power_of_ten, expected_value",
+    "value, power_of_ten, flow_direction, expected_value",
     [
-        (1234, 3, Decimal("1.234")),
-        (1234, 0, Decimal("1234")),
-        (1234, -3, Decimal("1234000")),
-        (0, 0, Decimal("0")),
-        (0, 10, Decimal("0")),
-        (0, -10, Decimal("0")),
+        (1234, 3, FlowDirectionType.FORWARD, Decimal("1.234")),
+        (1234, 3, FlowDirectionType.NOT_APPLICABLE, Decimal("1.234")),
+        (1234, 3, FlowDirectionType.REVERSE, Decimal("-1.234")),
+        (1234, 0, FlowDirectionType.FORWARD, Decimal("1234")),
+        (1234, -3, FlowDirectionType.FORWARD, Decimal("1234000")),
+        (1234, -3, FlowDirectionType.NOT_APPLICABLE, Decimal("1234000")),
+        (1234, -3, FlowDirectionType.REVERSE, Decimal("-1234000")),
+        (0, 0, FlowDirectionType.FORWARD, Decimal("0")),
+        (0, 10, FlowDirectionType.FORWARD, Decimal("0")),
+        (0, -10, FlowDirectionType.FORWARD, Decimal("0")),
+        (0, -10, FlowDirectionType.REVERSE, Decimal("0")),
     ],
 )
-def test_map_reading_value_power_of_ten(value: int, power_of_ten: int, expected_value: Decimal):
+def test_map_reading_value_power_of_ten(
+    value: int, power_of_ten: int, flow_direction: FlowDirectionType, expected_value: Decimal
+):
     """Validates that power of ten is correctly applied when setting value"""
     reading: SiteReading = generate_class_instance(SiteReading, generate_relationships=True)
     reading.value = value
     reading.site_reading_type.power_of_ten_multiplier = power_of_ten
+    reading.site_reading_type.flow_direction = flow_direction
 
     mapped = BillingMapper.map_reading(reading)
 
@@ -49,6 +58,130 @@ def test_map_reading_value_power_of_ten(value: int, power_of_ten: int, expected_
     assert mapped.duration_seconds == reading.time_period_seconds
 
 
+@pytest.mark.parametrize("optional_is_none", [True, False])
+def test_reading_type_to_billing_primacy_all_unique(optional_is_none: bool):
+    """Tests that all combos for reading_type_to_billing_primacy are unique integers (therefore they sort uniquely)"""
+
+    all_srts: list[SiteReadingType] = []
+    all_primacies: list[int] = []
+    for dq in DataQualifierType:
+        for ab in AccumulationBehaviourType:
+            srt: SiteReadingType = generate_class_instance(
+                SiteReadingType, optional_is_none=optional_is_none, data_qualifier=dq, accumulation_behaviour=ab
+            )
+            primacy = BillingMapper.reading_type_to_billing_primacy(srt)
+            assert isinstance(primacy, int)
+
+            alternative_primacy = BillingMapper.reading_type_to_billing_primacy(
+                generate_class_instance(
+                    SiteReadingType,
+                    seed=1001,
+                    optional_is_none=optional_is_none,
+                    data_qualifier=dq,
+                    accumulation_behaviour=ab,
+                )
+            )
+            assert alternative_primacy == primacy, "Values should be consistent (based on data_qual and accum behavior)"
+
+            all_srts.append(SiteReadingType)
+            all_primacies.append(primacy)
+
+    assert len(all_primacies) == len(all_srts)
+    assert len(all_primacies) > 5, "Sanity check - if this fails then what are iterating over?"
+    assert len(all_primacies) == len(set(all_primacies)), "All primacies should be unique integers"
+
+
+SRT_PRIMACY_HIGHEST: SiteReadingType = generate_class_instance(
+    SiteReadingType,
+    data_qualifier=DataQualifierType.AVERAGE,
+    accumulation_behaviour=AccumulationBehaviourType.SUMMATION,
+)
+
+SRT_PRIMACY_HIGH: SiteReadingType = generate_class_instance(
+    SiteReadingType,
+    data_qualifier=DataQualifierType.AVERAGE,
+    accumulation_behaviour=AccumulationBehaviourType.NOT_APPLICABLE,
+)
+
+SRT_PRIMACY_LOW: SiteReadingType = generate_class_instance(
+    SiteReadingType,
+    data_qualifier=DataQualifierType.MINIMUM,
+    accumulation_behaviour=AccumulationBehaviourType.INSTANTANEOUS,
+)
+
+SRT_PRIMACY_LOWEST: SiteReadingType = generate_class_instance(
+    SiteReadingType,
+    data_qualifier=DataQualifierType.NOT_APPLICABLE,
+    accumulation_behaviour=AccumulationBehaviourType.NOT_APPLICABLE,
+)
+
+
+def test_reading_type_to_billing_primacy_sanity_check():
+    """Tests that some "obvious" site types sort accordingly"""
+
+    highest_srt = BillingMapper.reading_type_to_billing_primacy(SRT_PRIMACY_HIGHEST)
+    high_srt = BillingMapper.reading_type_to_billing_primacy(SRT_PRIMACY_HIGH)
+    low_srt = BillingMapper.reading_type_to_billing_primacy(SRT_PRIMACY_LOW)
+    lowest_srt = BillingMapper.reading_type_to_billing_primacy(SRT_PRIMACY_LOWEST)
+
+    assert highest_srt > high_srt
+    assert high_srt > low_srt
+    assert low_srt > lowest_srt
+
+
+def gen_sr(value: int, srt: SiteReadingType) -> SiteReading:
+    """Shorthand for generating a new SiteReading with the specified value/type"""
+    return generate_class_instance(SiteReading, value=Decimal(value), site_reading_type=srt)
+
+
+@pytest.mark.parametrize(
+    "site_readings, expected_values",
+    [
+        ([], []),
+        ([gen_sr(1, SRT_PRIMACY_HIGHEST)], [1]),
+        ([gen_sr(2, SRT_PRIMACY_LOWEST)], [2]),
+        ([gen_sr(2, SRT_PRIMACY_LOWEST), gen_sr(3, SRT_PRIMACY_HIGHEST)], [3]),
+        ([gen_sr(1, SRT_PRIMACY_HIGHEST), gen_sr(2, SRT_PRIMACY_LOWEST)], [1]),
+        ([gen_sr(1, SRT_PRIMACY_HIGHEST), gen_sr(2, SRT_PRIMACY_LOWEST), gen_sr(3, SRT_PRIMACY_HIGHEST)], [1, 3]),
+        ([gen_sr(1, SRT_PRIMACY_LOWEST), gen_sr(2, SRT_PRIMACY_HIGHEST), gen_sr(3, SRT_PRIMACY_HIGHEST)], [2, 3]),
+        ([gen_sr(1, SRT_PRIMACY_HIGHEST), gen_sr(2, SRT_PRIMACY_LOWEST), gen_sr(3, SRT_PRIMACY_HIGH)], [1]),
+        (
+            [
+                gen_sr(1, SRT_PRIMACY_LOWEST),
+                gen_sr(2, SRT_PRIMACY_LOWEST),
+                gen_sr(3, SRT_PRIMACY_HIGH),
+                gen_sr(4, SRT_PRIMACY_LOW),
+                gen_sr(5, SRT_PRIMACY_HIGHEST),
+            ],
+            [5],
+        ),
+        (
+            [
+                gen_sr(1, SRT_PRIMACY_LOWEST),
+                gen_sr(2, SRT_PRIMACY_LOWEST),
+                gen_sr(3, SRT_PRIMACY_HIGH),
+                gen_sr(4, SRT_PRIMACY_HIGH),
+                gen_sr(5, SRT_PRIMACY_LOW),
+                gen_sr(6, SRT_PRIMACY_LOW),
+            ],
+            [3, 4],
+        ),
+    ],
+)
+def test_choose_best_billing_readings(site_readings: list[SiteReading], expected_values: list[int]):
+    """Tests that a known set of SiteReadings filter down to the highest primacy readings"""
+    result = BillingMapper.choose_best_billing_readings(site_readings)
+    assert_list_type(SiteReading, result, count=len(expected_values))
+    assert expected_values == [int(r.value) for r in result]
+
+    # Should also work with a reversed order too
+    site_readings.reverse()
+    expected_values.reverse()
+    result_reversed = BillingMapper.choose_best_billing_readings(site_readings)
+    assert_list_type(SiteReading, result_reversed, count=len(expected_values))
+    assert expected_values == [int(r.value) for r in result_reversed]
+
+
 TS_1 = datetime(2023, 1, 1, 1, 1, 1)
 TS_2 = datetime(2023, 2, 2, 2, 2, 2)
 
@@ -57,65 +190,87 @@ TS_2 = datetime(2023, 2, 2, 2, 2, 2)
     "expected_inputs, expected_outputs",
     [
         ([], []),  # Empty list
-        ([(1, TS_1, 100, -1)], [(1, TS_1, Decimal("1000"))]),  # Singleton
+        ([(1, TS_1, 100, -1, SRT_PRIMACY_HIGHEST)], [(1, TS_1, Decimal("1000"))]),  # Singleton
         (
-            [(1, TS_1, 100, -1), (1, TS_2, 100, 0)],
+            [(1, TS_1, 100, -1, SRT_PRIMACY_HIGHEST), (1, TS_2, 100, 0, SRT_PRIMACY_HIGHEST)],
             [(1, TS_1, Decimal("1000")), (1, TS_2, Decimal("100"))],
         ),  # Multiple, no aggregation, variation on timestamp
         (
-            [(1, TS_1, 1, 0), (2, TS_1, 2, 0)],
+            [(1, TS_1, 1, 0, SRT_PRIMACY_HIGHEST), (2, TS_1, 2, 0, SRT_PRIMACY_HIGHEST)],
             [(1, TS_1, Decimal("1")), (2, TS_1, Decimal("2"))],
         ),  # Multiple, no aggregation, variation on site
         (
             [
-                (1, TS_1, 1, 1),
-                (1, TS_1, 2, 2),
-                (1, TS_1, 3, 3),
+                (1, TS_1, 1, 1, SRT_PRIMACY_HIGHEST),
+                (1, TS_1, 2, 2, SRT_PRIMACY_HIGHEST),
+                (1, TS_1, 3, 3, SRT_PRIMACY_HIGHEST),
             ],
             [(1, TS_1, Decimal("0.123"))],
         ),  # Multiple, aggregate everything
         (
             [
-                (1, TS_1, 1, 1),
-                (1, TS_1, 2, 2),
-                (1, TS_1, 3, 3),
-                (1, TS_2, 4, 4),
+                (1, TS_1, 1, 1, SRT_PRIMACY_HIGHEST),
+                (1, TS_1, 2, 2, SRT_PRIMACY_LOW),
+                (1, TS_1, 3, 3, SRT_PRIMACY_HIGHEST),
+            ],
+            [(1, TS_1, Decimal("0.103"))],
+        ),  # Multiple, aggregate everything but only take the "best" readings
+        (
+            [
+                (1, TS_1, 1, 1, SRT_PRIMACY_LOWEST),
+                (1, TS_1, 2, 2, SRT_PRIMACY_LOWEST),
+                (1, TS_1, 3, 3, SRT_PRIMACY_LOWEST),
+                (1, TS_2, 4, 4, SRT_PRIMACY_LOWEST),
             ],
             [(1, TS_1, Decimal("0.123")), (1, TS_2, Decimal("0.0004"))],
         ),  # Multiple, some aggregation, finishing on non aggregate value
         (
             [
-                (1, TS_1, 4, -4),
-                (1, TS_2, 1, -1),
-                (1, TS_2, 2, -2),
-                (1, TS_2, 3, -3),
+                (1, TS_1, 4, -4, SRT_PRIMACY_HIGH),
+                (1, TS_2, 1, -1, SRT_PRIMACY_HIGH),
+                (1, TS_2, 2, -2, SRT_PRIMACY_HIGH),
+                (1, TS_2, 3, -3, SRT_PRIMACY_HIGH),
             ],
             [(1, TS_1, Decimal("40000")), (1, TS_2, Decimal("3210"))],
         ),  # Multiple, some aggregation, finishing on aggregate value
         (
             [
-                (1, TS_1, 1, 0),
-                (1, TS_1, 2, 0),
-                (1, TS_2, 3, 0),
-                (1, TS_2, 4, 0),
-                (2, TS_1, 5, 0),
-                (2, TS_2, 6, 0),
-                (2, TS_2, 7, 0),
+                (1, TS_1, 1, 0, SRT_PRIMACY_HIGH),
+                (1, TS_1, 2, 0, SRT_PRIMACY_HIGH),
+                (1, TS_2, 3, 0, SRT_PRIMACY_HIGH),
+                (1, TS_2, 4, 0, SRT_PRIMACY_HIGH),
+                (2, TS_1, 5, 0, SRT_PRIMACY_HIGH),
+                (2, TS_2, 6, 0, SRT_PRIMACY_HIGH),
+                (2, TS_2, 7, 0, SRT_PRIMACY_HIGH),
             ],
             [(1, TS_1, Decimal("3")), (1, TS_2, Decimal("7")), (2, TS_1, Decimal("5")), (2, TS_2, Decimal("13"))],
         ),  # Multiple aggregations
+        (
+            [
+                (1, TS_1, 1, 0, SRT_PRIMACY_HIGH),
+                (1, TS_1, 2, 0, SRT_PRIMACY_HIGHEST),
+                (1, TS_2, 3, 0, SRT_PRIMACY_LOW),
+                (1, TS_2, 4, 0, SRT_PRIMACY_HIGH),
+                (2, TS_1, 5, 0, SRT_PRIMACY_LOWEST),
+                (2, TS_2, 6, 0, SRT_PRIMACY_LOW),
+                (2, TS_2, 7, 0, SRT_PRIMACY_LOW),
+            ],
+            [(1, TS_1, Decimal("2")), (1, TS_2, Decimal("4")), (2, TS_1, Decimal("5")), (2, TS_2, Decimal("13"))],
+        ),  # Multiple aggregations - only best values for each aggregation
     ],
 )
 def test_aggregate_readings_for_site_timestamp(
-    expected_inputs: tuple[int, datetime, int, int], expected_outputs: tuple[int, datetime, Decimal]
+    expected_inputs: tuple[int, datetime, int, int, SiteReadingType], expected_outputs: tuple[int, datetime, Decimal]
 ):
     """Tests aggregate_readings_for_site_timestamp using a shorthand definition for input/output readings"""
     duration_seconds = 54123
 
     # Convert our simplified input data into real input site_readings
     input_site_readings: list[SiteReading] = []
-    for site_id, time_period_start, value_int, pow10 in expected_inputs:
+    for site_id, time_period_start, value_int, pow10, srt in expected_inputs:
         sr: SiteReading = generate_class_instance(SiteReading, generate_relationships=True)
+        cloned_srt: SiteReadingType = clone_class_instance(srt)  # Dont modify the global test variable
+        sr.site_reading_type = cloned_srt
         sr.site_reading_type.site_id = site_id
         sr.site_reading_type.power_of_ten_multiplier = pow10
         sr.time_period_seconds = duration_seconds


### PR DESCRIPTION
Fix for https://github.com/bsgip/envoy/issues/137

All BillingData endpoints will now better handle coincident readings of different aggregation methods (eg getting a MAX w/h and MEAN w/h reading for the same time will now mean ONLY the MEAN w/h reading will be included)