### PR TITLE
Added a simple readonly user for the admin server

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ Envoy has a number of configuration settings that turn on/off optional functiona
 
 Typically settings are set by setting an environment variable with the same name (case insensitive).
 
+**Common Settings**
 
 | **Setting** | **Type** | **Purpose** |
 | ----------- | -------- | ----------- |
 | `database_url` | `string` | The core `PostgresDsn` for connecting to the envoy database. eg `postgresql+asyncpg://envoyuser:mypass@localhost:5432/envoydb` |
-| `cert_header` | `string` | The name of the HTTP header that API endpoints will look for to validate a client. This should be set by the TLS termination point and can contain either a full client certificate in PEM format or the sha256 fingerprint of that certificate. defaults to "x-forwarded-client-cert" |
 | `default_timezone` | `string` | The timezone name that will be used as the default for new sites registered in band (defaults to "Australia/Brisbane") |
 | `enable_notifications` | `bool` | Whether notifications for active subscriptions will be generated. Notifications will either be handled in a local threadpool (if `rabbit_mq_broker_url` is None or via a dedicated task_iq worker connected to the same `rabbit_mq_broker_url` instance) |
 | `rabbit_mq_broker_url` | `string` | URL to a rabbit MQ instance that will handle notifications. Eg `amqp://user:password@localhost:5672`. Will require a worker servicing this instance |
@@ -34,8 +34,23 @@ Typically settings are set by setting an environment variable with the same name
 | `azure_ad_db_resource_id` | `string` | If set (with the other Azure AD options) - replaces the db connection password dynamically with a token minted from the tenant token service for this resource id. The token ID should match the resource ID of a managed database service. This token will be rotated as it expires. |
 | `azure_ad_db_refresh_secs` | `int` | If `azure_ad_db_resource_id` is set - the value of this variable will be the rate at which tokens are manually refreshed (in seconds) |
 | `href_prefix` | `string` | Used for when the server is exposed externally under a path prefix. The value of this variable will be prefixed to all returned `href` elements |
+
+**Additional Utility Server Settings (server)**
+
+| **Setting** | **Type** | **Purpose** |
+| ----------- | -------- | ----------- |
+| `cert_header` | `string` | The name of the HTTP header that API endpoints will look for to validate a client. This should be set by the TLS termination point and can contain either a full client certificate in PEM format or the sha256 fingerprint of that certificate. defaults to "x-forwarded-client-cert" |
 | `default_doe_import_active_watts` | `float` | If set - the DefaultDERControl endpoint will be activated with the DOE extensions for import being set to this value (requires `default_doe_export_active_watts`)|
 | `default_doe_export_active_watts` | `float` | If set - the DefaultDERControl endpoint will be activated with the DOE extensions for export being set to this value (requires `default_doe_import_active_watts`)|
+
+**Additional Admin Server Settings (admin)**
+
+| **Setting** | **Type** | **Purpose** |
+| ----------- | -------- | ----------- |
+| `admin_username` | `string` | The username for HTTP BASIC credentials that will grant "admin" access to all endpoints. Should only be used for tight integrations with local calculation engines |
+| `admin_password` | `string` | The password for HTTP BASIC credentials that pairs with `admin_username` |
+| `read_only_user` | `string` | The username for HTTP BASIC credentials that will grant "read only" access to all GET endpoints. |
+| `read_only_keys` | `list[string]` | Various passwords for HTTP BASIC credentials that each pair with `read_only_username`. Multiple entries should be encoded as a JSON list eg: `READ_ONLY_KEYS='"Password1", "Password2"]'` |
 
 ### Azure Active Directory Support + Managed Identity
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ markers = [
     "azure_ad_db: marks tests to enable the azure active directory dynamic db creds dependency (requires azure_ad_auth)",
     "azure_ad_db_refresh_secs: marks tests to set the config value azure_ad_db_refresh_secs (requires azure_ad_db)",
     "csipv11a_xmlns_optin_middleware: mark tests to install the csip-aus v11a xml namespace opt-in middleware",
+    "admin_ro_user: marks tests that install the admin server 'Read Only' user/passwords",
 ]
 
 [tool.bandit]

--- a/src/envoy/admin/api/depends.py
+++ b/src/envoy/admin/api/depends.py
@@ -2,7 +2,7 @@ import secrets
 from http import HTTPStatus
 from typing import Annotated
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 app = FastAPI()
@@ -11,17 +11,36 @@ security = HTTPBasic()
 
 class AdminAuthDepends:
     """
-    Dependency class that raises a 401 unauthorized exception if the provided admin_username
-    and admin_userpassword are not correct.
+    Dependency class that raises a 401 unauthorized / 403 forbidden exception if the incoming request BASIC
+    auth credentials don't match either the admin or readonly user values
     """
 
-    def __init__(self, username: str, password: str) -> None:
-        self.username = username
-        self.password = password
+    def __init__(
+        self, admin_username: str, admin_password: str, read_only_username: str, read_only_keys: list[str]
+    ) -> None:
+        self.admin_username = admin_username
+        self.admin_password = admin_password
+        self.read_only_username = read_only_username
+        self.read_only_keys = read_only_keys
 
-    async def __call__(self, credentials: Annotated[HTTPBasicCredentials, Depends(security)]) -> None:
-        is_correct_user = secrets.compare_digest(bytes(self.username, "utf-8"), bytes(credentials.username, "utf-8"))
-        is_correct_pass = secrets.compare_digest(bytes(self.password, "utf-8"), bytes(credentials.password, "utf-8"))
+    async def __call__(self, credentials: Annotated[HTTPBasicCredentials, Depends(security)], request: Request) -> None:
+        # If the creds match the admin user
+        if secrets.compare_digest(bytes(self.admin_username, "utf-8"), bytes(credentials.username, "utf-8")):
+            if secrets.compare_digest(bytes(self.admin_password, "utf-8"), bytes(credentials.password, "utf-8")):
+                return  # Authorised admin user
 
-        if not (is_correct_pass and is_correct_user):
-            raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Unauthorized")
+        # If the creds match the readonly user
+        if secrets.compare_digest(bytes(self.read_only_username, "utf-8"), bytes(credentials.username, "utf-8")):
+            for ro_key in self.read_only_keys:
+                if secrets.compare_digest(bytes(ro_key, "utf-8"), bytes(credentials.password, "utf-8")):
+                    # At this point we have a valid readonly key
+                    # Make sure they are trying to access a readonly resource
+                    if request.method == "GET" or request.method == "HEAD":
+                        return  # Authorised readonly user
+                    else:
+                        raise HTTPException(
+                            status_code=HTTPStatus.FORBIDDEN, detail="Only GET requests enabled for these credentials"
+                        )
+
+        # If no valid creds are matched - bail out with
+        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Unauthorized")

--- a/src/envoy/admin/main.py
+++ b/src/envoy/admin/main.py
@@ -42,7 +42,12 @@ def generate_app(new_settings: AppSettings) -> FastAPI:
             )
         )
 
-    admin_auth = AdminAuthDepends(settings.admin_username, settings.admin_password)
+    admin_auth = AdminAuthDepends(
+        new_settings.admin_username,
+        new_settings.admin_password,
+        new_settings.read_only_user,
+        new_settings.read_only_keys,
+    )
     new_app = FastAPI(
         **new_settings.fastapi_kwargs,
         dependencies=[Depends(admin_auth)],

--- a/src/envoy/admin/settings.py
+++ b/src/envoy/admin/settings.py
@@ -14,10 +14,11 @@ class AppSettings(CommonSettings):
     title: str = "envoy-admin"
     version: str = "0.0.0"
 
-    default_timezone: str = "Australia/Brisbane"
-
     admin_username: str
     admin_password: str
+
+    read_only_user: str = "rouser"
+    read_only_keys: list[str] = []  # Passwords that match with read_only_user and grant access to GET endpoints
 
     @property
     def fastapi_kwargs(self) -> Dict[str, Any]:

--- a/src/envoy/server/settings.py
+++ b/src/envoy/server/settings.py
@@ -14,7 +14,6 @@ class AppSettings(CommonSettings):
     version: str = "0.0.0"
 
     cert_header: str = "x-forwarded-client-cert"  # either client certificate in PEM format or the sha256 fingerprint
-    default_timezone: str = "Australia/Brisbane"
 
     default_doe_import_active_watts: Optional[str] = None  # Constant default DERControl import as a decimal float
     default_doe_export_active_watts: Optional[str] = None  # Constant default DERControl export as a decimal float

--- a/src/envoy/settings.py
+++ b/src/envoy/settings.py
@@ -37,6 +37,7 @@ class CommonSettings(BaseSettings):
     )
 
     database_url: PostgresDsn
+    default_timezone: str = "Australia/Brisbane"
 
     href_prefix: Optional[str] = None  # Will ensure all outgoing href's are prefixed with this value (None = disabled)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,11 +7,12 @@ from typing import Generator
 
 import alembic.config
 import pytest
-from assertical.fixtures.postgres import generate_async_conn_str_from_connection
 from assertical.fixtures.environment import environment_snapshot
+from assertical.fixtures.postgres import generate_async_conn_str_from_connection
 from psycopg import Connection
 from pytest_postgresql import factories
 
+from tests.integration.conftest import READONLY_USER_KEY_1, READONLY_USER_KEY_2, READONLY_USER_NAME
 from tests.unit.jwt import DEFAULT_CLIENT_ID, DEFAULT_DATABASE_RESOURCE_ID, DEFAULT_ISSUER, DEFAULT_TENANT_ID
 
 DEFAULT_DOE_IMPORT_ACTIVE_WATTS = Decimal("8200")
@@ -78,6 +79,10 @@ def pg_empty_config(
 
     if request.node.get_closest_marker("csipv11a_xmlns_optin_middleware"):
         os.environ["INSTALL_CSIP_V11A_OPT_IN_MIDDLEWARE"] = "true"
+
+    if request.node.get_closest_marker("admin_ro_user"):
+        os.environ["READ_ONLY_USER"] = READONLY_USER_NAME
+        os.environ["READ_ONLY_KEYS"] = f'["{READONLY_USER_KEY_1}", "{READONLY_USER_KEY_2}"]'
 
     # we want alembic to run from the server directory but to revert back afterwards
     cwd = os.getcwd()

--- a/tests/integration/general/test_admin.py
+++ b/tests/integration/general/test_admin.py
@@ -1,5 +1,8 @@
-import pytest
+import re
+from collections import defaultdict
 from http import HTTPStatus
+
+import pytest
 from httpx import AsyncClient
 
 from tests.integration.http import HTTPMethod
@@ -9,7 +12,9 @@ NO_AUTH_ROUTES = ["/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"]
 
 
 @pytest.mark.anyio
-async def test_get_resource_unauthorised(admin_client_unauth: AsyncClient, admin_path_methods: dict[list]):
+async def test_get_resource_unauthorised(
+    admin_client_unauth: AsyncClient, admin_path_methods: defaultdict[str, list[str]]
+):
     """Runs through the basic unauthorised tests across all routes"""
     routes = admin_path_methods
     client = admin_client_unauth
@@ -23,7 +28,9 @@ async def test_get_resource_unauthorised(admin_client_unauth: AsyncClient, admin
 
 
 @pytest.mark.anyio
-async def test_resource_with_invalid_methods(admin_client_auth: AsyncClient, admin_path_methods: dict[list]):
+async def test_resource_with_invalid_methods(
+    admin_client_auth: AsyncClient, admin_path_methods: defaultdict[str, list[str]]
+):
     """Runs through invalid HTTP methods for each endpoint"""
     routes = admin_path_methods
     client = admin_client_auth
@@ -32,3 +39,51 @@ async def test_resource_with_invalid_methods(admin_client_auth: AsyncClient, adm
         for method in [m for m in HTTPMethod if m.name not in methods]:
             resp = await client.request(method=method.name, url=path)
             assert_response_header(resp, HTTPStatus.METHOD_NOT_ALLOWED, expected_content_type="application/json")
+
+
+def infill_path_format_variables(path_format: str) -> str:
+    """Given a format like '/doe/{doe_id}' tries to guess and infill the parameters to return '/doe/1'. Tries
+    to be as clever as possible"""
+    pattern = r"\{([^\}]*)\}"
+    kvps = {}
+    for format_var_name in re.findall(pattern, path_format):
+        infill_value = 1
+        if "group" in format_var_name:
+            infill_value = "Group-1"
+        elif "start" in format_var_name or "end" in format_var_name:
+            infill_value = "2024-01-02T03:04:05Z"
+
+        kvps[format_var_name] = infill_value
+
+    return path_format.format(**kvps)
+
+
+@pytest.mark.anyio
+@pytest.mark.admin_ro_user
+async def test_readonly_client_can_only_access_get(
+    admin_client_readonly_auth: AsyncClient, admin_path_methods: dict[list]
+):
+    """Enumerates admin endpoints (that are protected) and ensures that the GET endpoints allow access but other methods
+    are locked down"""
+    for path, methods in admin_path_methods.items():
+        if path in NO_AUTH_ROUTES:
+            continue
+
+        for method in [m for m in HTTPMethod if m.name in methods]:
+            resp = await admin_client_readonly_auth.request(method=method.name, url=infill_path_format_variables(path))
+            if method == HTTPMethod.GET:
+                assert_response_header(resp, HTTPStatus.OK, expected_content_type="application/json")
+            else:
+                assert_response_header(resp, HTTPStatus.FORBIDDEN, expected_content_type="application/json")
+
+
+@pytest.mark.anyio
+async def test_readonly_client_not_installed(admin_client_readonly_auth: AsyncClient, admin_path_methods: dict[list]):
+    """Similar to test_readonly_client_can_only_access_get but with a bad set of credentials"""
+    for path, methods in admin_path_methods.items():
+        if path in NO_AUTH_ROUTES:
+            continue
+
+        for method in [m for m in HTTPMethod if m.name in methods]:
+            resp = await admin_client_readonly_auth.request(method=method.name, url=infill_path_format_variables(path))
+            assert_response_header(resp, HTTPStatus.UNAUTHORIZED, expected_content_type="application/json")

--- a/tests/integration/response.py
+++ b/tests/integration/response.py
@@ -32,10 +32,10 @@ def assert_response_header(
     body = read_response_body_string(response)
     assert (
         response.status_code == expected_status_code
-    ), f"Got HTTP {response.status_code} expected HTTP {expected_status_code} request: {response.request.url.path}\nResponse body:\n{body}"  # noqa E501
+    ), f"Got HTTP {response.status_code} expected HTTP {expected_status_code} request: {response.request.method} {response.request.url.path}\nResponse body:\n{body}"  # noqa E501
     assert (
         expected_content_type is not None and actual_content_type == expected_content_type
-    ), f"Got Content {actual_content_type} expected {expected_content_type} request: {response.request.url.path}\nResponse body:\n{body}"  # noqa E501
+    ), f"Got Content {actual_content_type} expected {expected_content_type} request:  {response.request.method} {response.request.url.path}\nResponse body:\n{body}"  # noqa E501
 
 
 def assert_error_response(response: httpx.Response):


### PR DESCRIPTION
Added `readonly_user` / `read_only_keys` to admin server. These will provide a secondary set of HTTP BASIC credentials (seperate from the admin creds) that we can distribute to externals. 

Incoming requests using these credentials will be granted access ONLY to HTTP GET endpoints.