### PR TITLE
Fixed some bad model definitions

### DIFF
--- a/src/envoy/admin/mapper/site.py
+++ b/src/envoy/admin/mapper/site.py
@@ -82,17 +82,25 @@ class SiteMapper:
         """Maps a DER Rating / Setting  associated with a site into a single DERConfiguration. Values from setting
         will be preferenced over values from rating"""
 
-        changed_time: datetime
-        modes_supported: DERControlType
+        changed_time: Optional[datetime] = None
+        modes_supported: Optional[DERControlType] = None
+
+        if rating:
+            changed_time = rating.changed_time
+            if rating.modes_supported is not None:
+                modes_supported = rating.modes_supported
+
         if setting:
             changed_time = setting.changed_time
-            modes_supported = setting.modes_enabled
-        elif rating:
-            changed_time = rating.changed_time
-            modes_supported = rating.modes_supported
-        else:
+            if setting.modes_enabled is not None:
+                modes_supported = setting.modes_enabled
+
+        if changed_time is None:
             # If setting and rating aren't set - just return None
             return None
+
+        if modes_supported is None:
+            modes_supported = DERControlType(0)
 
         doe_modes: DOESupportedMode = DOESupportedMode(0)
         if setting and setting.doe_modes_enabled is not None:

--- a/src/envoy/server/model/aggregator.py
+++ b/src/envoy/server/model/aggregator.py
@@ -26,8 +26,8 @@ class AggregatorCertificateAssignment(Base):
 
     __tablename__ = "aggregator_certificate_assignment"
     assignment_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    certificate_id = mapped_column(ForeignKey("certificate.certificate_id"), nullable=False)
-    aggregator_id = mapped_column(ForeignKey("aggregator.aggregator_id"), nullable=False)
+    certificate_id: Mapped[int] = mapped_column(ForeignKey("certificate.certificate_id"), nullable=False)
+    aggregator_id: Mapped[int] = mapped_column(ForeignKey("aggregator.aggregator_id"), nullable=False)
 
 
 class AggregatorDomain(Base):

--- a/src/envoy/server/model/base.py
+++ b/src/envoy/server/model/base.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from sqlalchemy import VARCHAR, DateTime
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -12,6 +14,6 @@ class Certificate(Base):
     __tablename__ = "certificate"
 
     certificate_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
-    created = mapped_column(DateTime(timezone=True))
-    lfdi = mapped_column(VARCHAR(length=42), nullable=False)
-    expiry = mapped_column(DateTime(timezone=True), nullable=False)
+    created: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    lfdi: Mapped[str] = mapped_column(VARCHAR(length=42), nullable=False)
+    expiry: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/src/envoy/server/model/site.py
+++ b/src/envoy/server/model/site.py
@@ -136,7 +136,7 @@ class SiteDERRating(Base):
     changed_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
 
     # These values correspond to a flattened version of sep2 DERCapability
-    modes_supported: Mapped[DERControlType] = mapped_column(INTEGER, nullable=True)
+    modes_supported: Mapped[Optional[DERControlType]] = mapped_column(INTEGER, nullable=True)
     abnormal_category: Mapped[Optional[AbnormalCategoryType]] = mapped_column(INTEGER, nullable=True)
     max_a_value: Mapped[Optional[int]] = mapped_column(INTEGER, nullable=True)
     max_a_multiplier: Mapped[Optional[int]] = mapped_column(INTEGER, nullable=True)
@@ -199,7 +199,7 @@ class SiteDERSetting(Base):
     changed_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
 
     # These values correspond to a flattened version of sep2 DERSettings
-    modes_enabled: Mapped[DERControlType] = mapped_column(INTEGER, nullable=True)
+    modes_enabled: Mapped[Optional[DERControlType]] = mapped_column(INTEGER, nullable=True)
     es_delay: Mapped[Optional[int]] = mapped_column(INTEGER, nullable=True)
     es_high_freq: Mapped[Optional[int]] = mapped_column(INTEGER, nullable=True)
     es_high_volt: Mapped[Optional[int]] = mapped_column(INTEGER, nullable=True)

--- a/tests/unit/server/model/test_models.py
+++ b/tests/unit/server/model/test_models.py
@@ -1,0 +1,48 @@
+import inspect
+from typing import get_type_hints
+
+import pytest
+from assertical.fake.generator import (
+    BASE_CLASS_PUBLIC_MEMBERS,
+    CLASS_MEMBER_FETCHERS,
+    get_generatable_class_base,
+    is_member_public,
+    is_optional_type,
+)
+from sqlalchemy.orm import MappedColumn
+
+import envoy.server.model as all_models
+from envoy.server.model import Base
+
+
+@pytest.mark.parametrize(
+    "model_type", [t for (name, t) in inspect.getmembers(all_models, inspect.isclass) if issubclass(t, Base)]
+)
+def test_validate_model_definitions(model_type: type):
+    """Runs some high level reflection checks on all model types to look for things that are "off" """
+    base = get_generatable_class_base(model_type)
+    type_hints = get_type_hints(model_type)
+
+    errors: list[str] = []
+    for member_name in CLASS_MEMBER_FETCHERS[base](model_type):
+        if not is_member_public(member_name):
+            continue
+        if member_name in BASE_CLASS_PUBLIC_MEMBERS[base]:
+            continue
+
+        mapped_column_details: MappedColumn = getattr(model_type, member_name)
+
+        if member_name not in type_hints:
+            errors.append(f"{member_name} is missing a type hint")
+            continue
+
+        member_type = type_hints[member_name]
+
+        type_hint_optional = is_optional_type(member_type)
+        sql_orm_nullable = getattr(mapped_column_details, "nullable", None)
+        if sql_orm_nullable is not None and type_hint_optional != sql_orm_nullable:
+            errors.append(
+                f"{member_name} has type hint {member_type} but has sqlalchemy ORM nullable {sql_orm_nullable}"
+            )
+
+    assert not errors, "\n".join(errors)


### PR DESCRIPTION
Certain model definitions were missing typehints or had type hints in conflict with the ORM definition (eg -not agreeing on nullable)

Added a test that scans all model types for these errors, fixed the instances that were found (and other downstream consequences)