### PR TITLE
Fixed limit being set to zero on edev raising errors

### DIFF
--- a/src/envoy/server/api/request.py
+++ b/src/envoy/server/api/request.py
@@ -60,7 +60,7 @@ def extract_default_doe(request: Request) -> Optional[DefaultDoeConfiguration]:
 
 def extract_limit_from_paging_param(limit: Optional[list[int]] = None) -> int:
     """Given a sep2 paging parameter called limit (as an int) - return the value, defaulting to DEFAULT_LIMIT if
-    not specified"""
+    not specified.  Can raise HTTPException for invalid values"""
     if limit is None or len(limit) == 0:
         return DEFAULT_LIMIT
 
@@ -68,16 +68,23 @@ def extract_limit_from_paging_param(limit: Optional[list[int]] = None) -> int:
     if limit_val > MAX_LIMIT:
         return MAX_LIMIT
 
+    if limit_val < 0:
+        raise HTTPException(HTTPStatus.BAD_REQUEST, "l parameters must be >= 0")
+
     return limit_val
 
 
 def extract_start_from_paging_param(start: Optional[list[int]] = None) -> int:
     """Given a sep2 paging parameter called start (as an int) - return the value, defaulting to DEFAULT_START if
-    not specified"""
+    not specified. Can raise HTTPException for invalid values"""
     if start is None or len(start) == 0:
         return DEFAULT_START
 
-    return start[0]
+    start_val = start[0]
+    if start_val < 0:
+        raise HTTPException(HTTPStatus.BAD_REQUEST, "s parameters must be >= 0")
+
+    return start_val
 
 
 def extract_datetime_from_paging_param(after: Optional[list[int]] = None) -> datetime:

--- a/src/envoy/server/manager/end_device.py
+++ b/src/envoy/server/manager/end_device.py
@@ -52,7 +52,13 @@ async def fetch_sites_and_count_for_claims(
             scope.aggregator_id,
         )
         if site and site.changed_time > after:
-            return ([site], 1)
+            if start == 0 and limit > 0:
+                return ([site], 1)  # We will honour the pagination directives
+            else:
+                return (
+                    [],
+                    1,
+                )  # pagination isn't fetching the first element in the list, return empty but list total
         else:
             return ([], 0)
     elif scope.source == CertificateType.AGGREGATOR_CERTIFICATE:

--- a/src/envoy/server/manager/end_device.py
+++ b/src/envoy/server/manager/end_device.py
@@ -224,15 +224,16 @@ class EndDeviceListManager:
         # Include the aggregator virtual site?
         if includes_virtual_site:
             if start == 0:
-                # Get the virtual site associated with the aggregator
-                virtual_site = await get_virtual_site_for_aggregator(
-                    session=session,
-                    aggregator_id=scope.aggregator_id,
-                    aggregator_lfdi=scope.lfdi,
-                )
+                if limit > 0:
+                    # Get the virtual site associated with the aggregator
+                    virtual_site = await get_virtual_site_for_aggregator(
+                        session=session,
+                        aggregator_id=scope.aggregator_id,
+                        aggregator_lfdi=scope.lfdi,
+                    )
 
                 # Adjust limit to account for the virtual site
-                limit -= 1
+                limit = max(0, limit - 1)
 
             # Ensure a start value of either 0 or 1 will return the first site for the aggregator
             start = max(0, start - 1)

--- a/src/envoy/server/manager/end_device.py
+++ b/src/envoy/server/manager/end_device.py
@@ -51,15 +51,18 @@ async def fetch_sites_and_count_for_claims(
             scope.lfdi,
             scope.aggregator_id,
         )
+
         if site and site.changed_time > after:
+            # We have a site (and it's not filtered out) - now apply our "virtual" pagination
             if start == 0 and limit > 0:
-                return ([site], 1)  # We will honour the pagination directives
+                return ([site], 1)  # If pagination allows the first record through - send it
             else:
                 return (
                     [],
                     1,
                 )  # pagination isn't fetching the first element in the list, return empty but list total
         else:
+            # If we are here - there either isn't a registered site OR it's been filtered by the query. Return empty
             return ([], 0)
     elif scope.source == CertificateType.AGGREGATOR_CERTIFICATE:
         site_list = await select_all_sites_with_aggregator_id(session, scope.aggregator_id, start, after, limit)

--- a/tests/integration/func_sets/test_end_device.py
+++ b/tests/integration/func_sets/test_end_device.py
@@ -131,6 +131,10 @@ async def test_get_end_device_list_by_aggregator(
             1,
             AGG_2_VALID_CERT,
         ),
+        # Validating edge cases where a zero/negative limit caused issues
+        (build_paging_params(limit=-1), [], 4, AGG_1_VALID_CERT),
+        (build_paging_params(limit=0), [], 4, AGG_1_VALID_CERT),
+        (build_paging_params(limit=0.123), [], 4, AGG_1_VALID_CERT),
     ],
 )
 @pytest.mark.anyio

--- a/tests/integration/func_sets/test_end_device.py
+++ b/tests/integration/func_sets/test_end_device.py
@@ -131,10 +131,13 @@ async def test_get_end_device_list_by_aggregator(
             1,
             AGG_2_VALID_CERT,
         ),
+        # Testing a device certificate
+        (build_paging_params(limit=10), [int(REGISTERED_CERT_SFDI)], 1, REGISTERED_CERT),
         # Validating edge cases where a zero/negative limit caused issues
         (build_paging_params(limit=-1), [], 4, AGG_1_VALID_CERT),
         (build_paging_params(limit=0), [], 4, AGG_1_VALID_CERT),
-        (build_paging_params(limit=0.123), [], 4, AGG_1_VALID_CERT),
+        (build_paging_params(limit=-1), [], 1, REGISTERED_CERT),
+        (build_paging_params(limit=0), [], 1, REGISTERED_CERT),
     ],
 )
 @pytest.mark.anyio

--- a/tests/integration/func_sets/test_end_device.py
+++ b/tests/integration/func_sets/test_end_device.py
@@ -152,10 +152,8 @@ async def test_get_end_device_list_invalid_pagination(
         ),
         # Testing a device certificate
         (build_paging_params(limit=10), [int(REGISTERED_CERT_SFDI)], 1, REGISTERED_CERT),
-        # Validating edge cases where a zero/negative limit caused issues
-        (build_paging_params(limit=-1), [], 4, AGG_1_VALID_CERT),
+        # Validating edge cases where a zero limit caused issues
         (build_paging_params(limit=0), [], 4, AGG_1_VALID_CERT),
-        (build_paging_params(limit=-1), [], 1, REGISTERED_CERT),
         (build_paging_params(limit=0), [], 1, REGISTERED_CERT),
     ],
 )

--- a/tests/integration/func_sets/test_end_device.py
+++ b/tests/integration/func_sets/test_end_device.py
@@ -90,6 +90,25 @@ async def test_get_end_device_list_by_aggregator(
 
 
 @pytest.mark.parametrize(
+    "query_string, cert",
+    [
+        (build_paging_params(limit=-1), AGG_1_VALID_CERT),
+        (build_paging_params(limit=-1), REGISTERED_CERT),
+        (build_paging_params(start=-1), AGG_1_VALID_CERT),
+        (build_paging_params(start=-1), REGISTERED_CERT),
+    ],
+)
+@pytest.mark.anyio
+async def test_get_end_device_list_invalid_pagination(
+    client: AsyncClient, edev_base_uri: str, query_string: str, cert: str
+):
+    """Tests that invalid pagination variables on the list endpoint return bad requests"""
+    response = await client.get(edev_base_uri + query_string, headers={cert_header: urllib.parse.quote(cert)})
+    assert_response_header(response, HTTPStatus.BAD_REQUEST)
+    assert_error_response(response)
+
+
+@pytest.mark.parametrize(
     "query_string, site_sfdis, expected_total, cert",
     [
         (build_paging_params(limit=1), [int(AGG_1_SFDI_FROM_VALID_CERT)], 4, AGG_1_VALID_CERT),

--- a/tests/unit/server/api/test_request.py
+++ b/tests/unit/server/api/test_request.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime, timezone
-from typing import Optional
+from typing import Optional, Union
 
 import pytest
+from fastapi import HTTPException
 
 from envoy.server.api.request import (
     DEFAULT_DATETIME,
@@ -25,10 +26,16 @@ from envoy.server.api.request import (
         ([4, 5, 6], 4),
         (None, DEFAULT_LIMIT),
         ([], DEFAULT_LIMIT),
+        ([-1], HTTPException),
+        ([-99], HTTPException),
     ],
 )
-def test_extract_limit_from_paging_param(query_val: Optional[list[int]], expected_output: int):
-    assert extract_limit_from_paging_param(query_val) == expected_output
+def test_extract_limit_from_paging_param(query_val: Optional[list[int]], expected_output: Union[int, type]):
+    if isinstance(expected_output, type):
+        with pytest.raises(expected_output):
+            extract_limit_from_paging_param(query_val)
+    else:
+        assert extract_limit_from_paging_param(query_val) == expected_output
 
 
 @pytest.mark.parametrize(
@@ -41,10 +48,17 @@ def test_extract_limit_from_paging_param(query_val: Optional[list[int]], expecte
         ([4, 5, 6], 4),
         (None, DEFAULT_START),
         ([], DEFAULT_START),
+        ([-1], HTTPException),
+        ([-99], HTTPException),
     ],
 )
-def test_extract_start_from_paging_param(query_val: Optional[list[int]], expected_output: int):
-    assert extract_start_from_paging_param(query_val) == expected_output
+def test_extract_start_from_paging_param(query_val: Optional[list[int]], expected_output: Union[int, type]):
+
+    if isinstance(expected_output, type):
+        with pytest.raises(expected_output):
+            extract_start_from_paging_param(query_val)
+    else:
+        assert extract_start_from_paging_param(query_val) == expected_output
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix for https://github.com/bsgip/envoy/issues/174

edev manager was just blindly subtracting 1 without handling a limit at (or below) zero.

Device cert pagination on edev was also a little wonky (not honouring pagination directives) - That has also been fixed