### PR TITLE
Fixes for Device Capability response all attributes

### DIFF
--- a/src/envoy/server/manager/device_capability.py
+++ b/src/envoy/server/manager/device_capability.py
@@ -1,10 +1,9 @@
 from datetime import datetime
-from typing import Optional
 
 from envoy_schema.server.schema.sep2.device_capability import DeviceCapabilityResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from envoy.server.crud.end_device import select_single_site_with_lfdi, select_aggregator_site_count
+from envoy.server.crud.end_device import select_aggregator_site_count, select_single_site_with_lfdi
 from envoy.server.crud.site_reading import count_site_reading_types_for_aggregator  # is this mup?
 from envoy.server.mapper.sep2.device_capability import DeviceCapabilityMapper
 from envoy.server.request_scope import CertificateType, UnregisteredRequestScope
@@ -17,17 +16,23 @@ class DeviceCapabilityManager:
     ) -> DeviceCapabilityResponse:
         """Noting this operates on a RawRequestScope - any client getting through the TLS termination can utilise this
         call (as is intended)"""
-        site_id_scope: Optional[int] = None
+        edev_cnt: int
+        mup_cnt: int
+
+        # Aggregator certs need to be treated differently from device certs
         if scope.source == CertificateType.DEVICE_CERTIFICATE:
             existing_device_site = await select_single_site_with_lfdi(session, scope.lfdi, scope.aggregator_id)
             if existing_device_site is None:
                 return DeviceCapabilityMapper.map_to_unregistered_response(scope=scope)
             else:
-                site_id_scope = existing_device_site.site_id
+                edev_cnt = 1
+                mup_cnt = await count_site_reading_types_for_aggregator(
+                    session, scope.aggregator_id, existing_device_site.site_id, datetime.min
+                )
+        else:
+            # Aggregator certificate
+            edev_cnt = await select_aggregator_site_count(session, scope.aggregator_id, datetime.min)
+            edev_cnt += 1  # Adjust the count to include the virtual aggregator end device at "edev/0"
+            mup_cnt = await count_site_reading_types_for_aggregator(session, scope.aggregator_id, None, datetime.min)
 
-        # Get all counts needed to form the 'Link's and 'ListLink's in a device capability response (registered)
-        edev_cnt = await select_aggregator_site_count(session, scope.aggregator_id, datetime.min)
-        mup_cnt = await count_site_reading_types_for_aggregator(
-            session, scope.aggregator_id, site_id_scope, datetime.min
-        )
         return DeviceCapabilityMapper.map_to_response(scope=scope, edev_cnt=edev_cnt, mup_cnt=mup_cnt)

--- a/src/envoy/server/mapper/sep2/device_capability.py
+++ b/src/envoy/server/mapper/sep2/device_capability.py
@@ -1,6 +1,7 @@
 from envoy_schema.server.schema import uri
 from envoy_schema.server.schema.sep2.device_capability import DeviceCapabilityResponse
-from envoy_schema.server.schema.sep2.identification import ListLink, Link
+from envoy_schema.server.schema.sep2.identification import Link, ListLink
+
 from envoy.server.mapper.common import generate_href
 from envoy.server.request_scope import BaseRequestScope
 
@@ -37,4 +38,5 @@ class DeviceCapabilityMapper:
                 href=generate_href(uri.MirrorUsagePointListUri, scope),
                 all_=0,  # mup requires edev (referenced via non-optional deviceLFDI), so must be 0 here
             ),
+            TimeLink=Link(href=generate_href(uri.TimeUri, scope)),
         )

--- a/src/envoy/server/mapper/sep2/end_device.py
+++ b/src/envoy/server/mapper/sep2/end_device.py
@@ -52,6 +52,7 @@ class VirtualEndDeviceMapper:
     @staticmethod
     def map_to_response(scope: BaseRequestScope, site: Site) -> EndDeviceResponse:
         edev_href = generate_href(uri.EndDeviceUri, scope, site_id=site.site_id)
+        pubsub_href = generate_href(uri.SubscriptionListUri, scope, site_id=site.site_id)
         return EndDeviceResponse.model_validate(
             {
                 "href": edev_href,
@@ -61,6 +62,7 @@ class VirtualEndDeviceMapper:
                 "deviceCategory": f"{site.device_category:x}",  # deviceCategory is a hex string
                 "changedTime": int(site.changed_time.timestamp()),
                 "enabled": True,
+                "SubscriptionListLink": ListLink(href=pubsub_href),
             }
         )
 

--- a/tests/integration/func_sets/test_device_capability.py
+++ b/tests/integration/func_sets/test_device_capability.py
@@ -1,20 +1,46 @@
 from http import HTTPStatus
+from urllib.parse import quote
 
 import pytest
 from envoy_schema.server.schema import uri
 from envoy_schema.server.schema.sep2.device_capability import DeviceCapabilityResponse
 from httpx import AsyncClient
 
+from tests.data.certificates.certificate1 import TEST_CERTIFICATE_PEM as AGG_1_VALID_CERT
+from tests.data.certificates.certificate4 import TEST_CERTIFICATE_PEM as AGG_2_VALID_CERT
+from tests.data.certificates.certificate7 import TEST_CERTIFICATE_PEM as DEVICE_REGISTERED_CERT
+from tests.data.certificates.certificate8 import TEST_CERTIFICATE_PEM as DEVICE_UNREGISTERED_CERT
+from tests.integration.integration_server import cert_header
 from tests.integration.response import assert_response_header, read_response_body_string
 
 
+@pytest.mark.parametrize(
+    "cert, edev_count, mup_count, expects_tm",
+    [
+        (AGG_1_VALID_CERT, 4, 3, True),  # Agg 1 - 3 edevs + agg edev
+        (AGG_2_VALID_CERT, 2, 0, True),  # Agg 2 - 1 edevs+ agg edev
+        (DEVICE_REGISTERED_CERT, 1, 0, True),  # Device cert - no agg edev
+        (DEVICE_UNREGISTERED_CERT, 0, 0, False),  # Device cert - no agg edev
+    ],
+)
 @pytest.mark.anyio
-async def test_get_device_capability(client: AsyncClient, valid_headers: dict):
-    """Simple test of a valid get - validates that the response looks like XML"""
-    response = await client.get(uri.DeviceCapabilityUri, headers=valid_headers)
+async def test_get_device_capability(client: AsyncClient, cert: str, edev_count: int, mup_count: int, expects_tm: bool):
+    """Simple test of a valid get - validates that the response looks like XML and that the dcap counts are accurate"""
+    response = await client.get(uri.DeviceCapabilityUri, headers={cert_header: quote(cert)})
     assert_response_header(response, HTTPStatus.OK)
     body = read_response_body_string(response)
     assert len(body) > 0
 
     parsed_response: DeviceCapabilityResponse = DeviceCapabilityResponse.from_xml(body)
     assert parsed_response.href == uri.DeviceCapabilityUri
+
+    if expects_tm:
+        assert parsed_response.TimeLink is not None
+    else:
+        assert parsed_response.TimeLink is None
+
+    assert parsed_response.EndDeviceListLink is not None
+    assert parsed_response.EndDeviceListLink.all_ == edev_count
+
+    assert parsed_response.MirrorUsagePointListLink is not None
+    assert parsed_response.MirrorUsagePointListLink.all_ == mup_count

--- a/tests/integration/func_sets/test_device_capability.py
+++ b/tests/integration/func_sets/test_device_capability.py
@@ -15,16 +15,16 @@ from tests.integration.response import assert_response_header, read_response_bod
 
 
 @pytest.mark.parametrize(
-    "cert, edev_count, mup_count, expects_tm",
+    "cert, edev_count, mup_count",
     [
-        (AGG_1_VALID_CERT, 4, 3, True),  # Agg 1 - 3 edevs + agg edev
-        (AGG_2_VALID_CERT, 2, 0, True),  # Agg 2 - 1 edevs+ agg edev
-        (DEVICE_REGISTERED_CERT, 1, 0, True),  # Device cert - no agg edev
-        (DEVICE_UNREGISTERED_CERT, 0, 0, False),  # Device cert - no agg edev
+        (AGG_1_VALID_CERT, 4, 3),  # Agg 1 - 3 edevs + agg edev
+        (AGG_2_VALID_CERT, 2, 0),  # Agg 2 - 1 edevs+ agg edev
+        (DEVICE_REGISTERED_CERT, 1, 0),  # Device cert - no agg edev
+        (DEVICE_UNREGISTERED_CERT, 0, 0),  # Device cert - no agg edev
     ],
 )
 @pytest.mark.anyio
-async def test_get_device_capability(client: AsyncClient, cert: str, edev_count: int, mup_count: int, expects_tm: bool):
+async def test_get_device_capability(client: AsyncClient, cert: str, edev_count: int, mup_count: int):
     """Simple test of a valid get - validates that the response looks like XML and that the dcap counts are accurate"""
     response = await client.get(uri.DeviceCapabilityUri, headers={cert_header: quote(cert)})
     assert_response_header(response, HTTPStatus.OK)
@@ -34,10 +34,7 @@ async def test_get_device_capability(client: AsyncClient, cert: str, edev_count:
     parsed_response: DeviceCapabilityResponse = DeviceCapabilityResponse.from_xml(body)
     assert parsed_response.href == uri.DeviceCapabilityUri
 
-    if expects_tm:
-        assert parsed_response.TimeLink is not None
-    else:
-        assert parsed_response.TimeLink is None
+    assert parsed_response.TimeLink is not None
 
     assert parsed_response.EndDeviceListLink is not None
     assert parsed_response.EndDeviceListLink.all_ == edev_count

--- a/tests/unit/server/manager/test_device_capability.py
+++ b/tests/unit/server/manager/test_device_capability.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 import unittest.mock as mock
+from datetime import datetime
 
 import pytest
 from assertical.fake.generator import generate_class_instance
@@ -23,7 +23,7 @@ async def test_device_capability_manager_aggregator_scope(
     mock_map_to_unregistered_response: mock.Mock,
     mock_map_to_response: mock.Mock,
 ):
-    """Tests that device cert that is registered returns properly offloads to the full response"""
+    """Tests that device cert that is registered as an aggregator properly offloads to the full response"""
 
     # Arrange
     mock_session = create_mock_session()
@@ -31,8 +31,8 @@ async def test_device_capability_manager_aggregator_scope(
     scope: UnregisteredRequestScope = generate_class_instance(
         UnregisteredRequestScope, source=CertificateType.AGGREGATOR_CERTIFICATE
     )
-    mock_select_aggregator_site_count.return_value = 0
-    mock_count_site_reading_types_for_aggregator.return_value = 0
+    mock_select_aggregator_site_count.return_value = 11
+    mock_count_site_reading_types_for_aggregator.return_value = 22
 
     # Act
     assert (
@@ -48,7 +48,9 @@ async def test_device_capability_manager_aggregator_scope(
     mock_count_site_reading_types_for_aggregator.assert_called_once_with(
         mock_session, scope.aggregator_id, None, datetime.min
     )
-    mock_map_to_response.assert_called_once_with(scope=scope, edev_cnt=0, mup_cnt=0)
+    mock_map_to_response.assert_called_once_with(
+        scope=scope, edev_cnt=12, mup_cnt=22
+    )  # The edev count must also include aggregator end device
 
 
 @pytest.mark.anyio

--- a/tests/unit/server/manager/test_device_capability.py
+++ b/tests/unit/server/manager/test_device_capability.py
@@ -109,8 +109,7 @@ async def test_device_capability_manager_registered_device_scope(
     mock_session = create_mock_session()
     existing_site: Site = generate_class_instance(Site, seed=1001)
     mock_select_single_site_with_lfdi.return_value = existing_site
-    mock_select_aggregator_site_count.return_value = 1
-    mock_count_site_reading_types_for_aggregator.return_value = 0
+    mock_count_site_reading_types_for_aggregator.return_value = 99
     mock_map_to_response.return_value = mock.Mock()
     scope: UnregisteredRequestScope = generate_class_instance(
         UnregisteredRequestScope, source=CertificateType.DEVICE_CERTIFICATE
@@ -125,8 +124,10 @@ async def test_device_capability_manager_registered_device_scope(
     assert_mock_session(mock_session, committed=False)
     mock_map_to_unregistered_response.assert_not_called()
     mock_select_single_site_with_lfdi.assert_called_once_with(mock_session, scope.lfdi, scope.aggregator_id)
-    mock_select_aggregator_site_count.assert_called_once_with(mock_session, scope.aggregator_id, datetime.min)
+    mock_select_aggregator_site_count.assert_not_called()  # We don't count - just having the edev means we have 1 site
     mock_count_site_reading_types_for_aggregator.assert_called_once_with(
         mock_session, scope.aggregator_id, existing_site.site_id, datetime.min
     )
-    mock_map_to_response.assert_called_once_with(scope=scope, edev_cnt=1, mup_cnt=0)
+    mock_map_to_response.assert_called_once_with(
+        scope=scope, edev_cnt=1, mup_cnt=99
+    )  # 2 edevs, one for the returned edev and one for the virtual aggregator edev


### PR DESCRIPTION
Fix for https://github.com/bsgip/envoy/issues/173

DCap responses for device/aggregator certs were reporting incorrect counts.