### PR TITLE
Allows for the setting of arbitrary sql alchemy create_engine args

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Typically settings are set by setting an environment variable with the same name
 | `azure_ad_db_refresh_secs` | `int` | If `azure_ad_db_resource_id` is set - the value of this variable will be the rate at which tokens are manually refreshed (in seconds) |
 | `href_prefix` | `string` | Used for when the server is exposed externally under a path prefix. The value of this variable will be prefixed to all returned `href` elements |
 | `iana_pen` | `int` | Defaults to 0. The Internet Assigned Numbers Authority - Private Enterprise Number of the organisation hosting this instance. This value will be used in all encoded MRIDs as per sep2 specifications. |
-| `sql_alchemy_engine_arguments` | `str` | A JSON encoded dictionary of additional parameters to pass to the SQL Alchemy `create_engine` function. Please see the [SQL Alchemy](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine) docs for specifics.  Example: `{"pool_size":10, "max_overflow":15}`. Please note that `pool_recycle` will be overridden if `azure_ad_db_refresh_secs` is set |
+| `sqlalchemy_engine_arguments` | `str` | A JSON encoded dictionary of additional parameters to pass to the SQL Alchemy `create_engine` function. Please see the [SQL Alchemy](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine) docs for specifics.  Example: `{"pool_size":10, "max_overflow":15}`. Please note that `pool_recycle` will be overridden if `azure_ad_db_refresh_secs` is set |
 
 **Additional Utility Server Settings (server)**
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Typically settings are set by setting an environment variable with the same name
 | `azure_ad_db_refresh_secs` | `int` | If `azure_ad_db_resource_id` is set - the value of this variable will be the rate at which tokens are manually refreshed (in seconds) |
 | `href_prefix` | `string` | Used for when the server is exposed externally under a path prefix. The value of this variable will be prefixed to all returned `href` elements |
 | `iana_pen` | `int` | Defaults to 0. The Internet Assigned Numbers Authority - Private Enterprise Number of the organisation hosting this instance. This value will be used in all encoded MRIDs as per sep2 specifications. |
+| `sql_alchemy_engine_arguments` | `str` | A JSON encoded dictionary of additional parameters to pass to the SQL Alchemy `create_engine` function. Please see the [SQL Alchemy](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine) docs for specifics.  Example: `{"pool_size":10, "max_overflow":15}`. Please note that `pool_recycle` will be overridden if `azure_ad_db_refresh_secs` is set |
 
 **Additional Utility Server Settings (server)**
 

--- a/src/envoy/settings.py
+++ b/src/envoy/settings.py
@@ -7,14 +7,14 @@ from pydantic_settings import BaseSettings
 def generate_middleware_kwargs(
     database_url: str,
     commit_on_exit: bool,
-    sql_alchemy_engine_args: Optional[dict[str, Any]],
+    sqlalchemy_engine_args: Optional[dict[str, Any]],
     azure_ad_db_resource_id: Optional[str],
     azure_ad_db_refresh_secs: Optional[int],
 ) -> dict[str, Any]:
     """Generates kwargs for SQLAlchemyMiddleware for a given set of settings values"""
     settings = {"db_url": database_url, "commit_on_exit": commit_on_exit}
 
-    engine_args = sql_alchemy_engine_args.copy() if sql_alchemy_engine_args is not None else {}
+    engine_args = sqlalchemy_engine_args.copy() if sqlalchemy_engine_args is not None else {}
 
     # this setting causes the pool to recycle connections after the given number of seconds has passed
     # It will ensure that connections won't stay live in the pool after the tokens are refreshed
@@ -48,14 +48,14 @@ class CommonSettings(BaseSettings):
     href_prefix: Optional[str] = None  # Will ensure all outgoing href's are prefixed with this value (None = disabled)
     iana_pen: int = 0  # The IANA Private Enterprise Number of the organisation hosting this instance. Encoded in mrids
 
-    sql_alchemy_engine_arguments: Optional[dict[str, Union[str, int, float]]] = None
+    sqlalchemy_engine_arguments: Optional[dict[str, Union[str, int, float]]] = None
 
     @property
     def db_middleware_kwargs(self) -> Dict[str, Any]:
         return generate_middleware_kwargs(
             database_url=str(self.database_url),
             commit_on_exit=False,
-            sql_alchemy_engine_args=self.sql_alchemy_engine_arguments,
+            sqlalchemy_engine_args=self.sqlalchemy_engine_arguments,
             azure_ad_db_resource_id=self.azure_ad_db_resource_id,
             azure_ad_db_refresh_secs=self.azure_ad_db_refresh_secs,
         )

--- a/src/envoy/settings.py
+++ b/src/envoy/settings.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from pydantic import PostgresDsn
 from pydantic_settings import BaseSettings
@@ -7,16 +7,22 @@ from pydantic_settings import BaseSettings
 def generate_middleware_kwargs(
     database_url: str,
     commit_on_exit: bool,
+    sql_alchemy_engine_args: Optional[dict[str, Any]],
     azure_ad_db_resource_id: Optional[str],
     azure_ad_db_refresh_secs: Optional[int],
 ) -> dict[str, Any]:
     """Generates kwargs for SQLAlchemyMiddleware for a given set of settings values"""
     settings = {"db_url": database_url, "commit_on_exit": commit_on_exit}
 
+    engine_args = sql_alchemy_engine_args.copy() if sql_alchemy_engine_args is not None else {}
+
     # this setting causes the pool to recycle connections after the given number of seconds has passed
     # It will ensure that connections won't stay live in the pool after the tokens are refreshed
     if azure_ad_db_resource_id and azure_ad_db_refresh_secs:
-        settings["engine_args"] = {"pool_recycle": azure_ad_db_refresh_secs}
+        engine_args["pool_recycle"] = azure_ad_db_refresh_secs
+
+    if engine_args:
+        settings["engine_args"] = engine_args
     return settings
 
 
@@ -42,11 +48,14 @@ class CommonSettings(BaseSettings):
     href_prefix: Optional[str] = None  # Will ensure all outgoing href's are prefixed with this value (None = disabled)
     iana_pen: int = 0  # The IANA Private Enterprise Number of the organisation hosting this instance. Encoded in mrids
 
+    sql_alchemy_engine_arguments: Optional[dict[str, Union[str, int, float]]] = None
+
     @property
     def db_middleware_kwargs(self) -> Dict[str, Any]:
         return generate_middleware_kwargs(
             database_url=str(self.database_url),
             commit_on_exit=False,
+            sql_alchemy_engine_args=self.sql_alchemy_engine_arguments,
             azure_ad_db_resource_id=self.azure_ad_db_resource_id,
             azure_ad_db_refresh_secs=self.azure_ad_db_refresh_secs,
         )

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,65 @@
+import os
+
+import pytest
+from assertical.fixtures.environment import delete_environment_variable
+from pydantic import PostgresDsn
+from pydantic_core import ValidationError
+
+from envoy.settings import CommonSettings, generate_middleware_kwargs
+
+TEST_DATABASE_URL = "postgresql+asyncpg://u:p@localhost:1122/mydb"  # Should validate as a valid postgresql DSN
+
+
+def remove_mandatory_settings():
+    delete_environment_variable("DATABASE_URL")
+
+
+def test_settings_missing_mandatory(preserved_environment):
+    """Do we get errors if the mandatory setting keys are missing"""
+    remove_mandatory_settings()
+    with pytest.raises(ValidationError):
+        CommonSettings(_env_file=None)
+
+
+def test_settings_defaults(preserved_environment):
+    """Don't set any config values - just let it load with defaults and no errors"""
+
+    # Reset config
+    remove_mandatory_settings()
+    os.environ["DATABASE_URL"] = TEST_DATABASE_URL
+
+    settings = CommonSettings()
+
+    assert settings.enable_notifications is None
+    assert settings.sql_alchemy_engine_arguments is None
+    assert settings.database_url == PostgresDsn(TEST_DATABASE_URL)
+    assert isinstance(settings.db_middleware_kwargs, dict)
+
+
+def test_settings_engine_args(preserved_environment):
+    """Don't set any config values - just let it load with defaults and no errors"""
+
+    # Reset config
+    remove_mandatory_settings()
+    os.environ["DATABASE_URL"] = TEST_DATABASE_URL
+    os.environ["SQL_ALCHEMY_ENGINE_ARGUMENTS"] = '{"foo": "bar", "num": 123, "bool": true, "float": 1.23}'
+
+    settings = CommonSettings()
+    assert settings.sql_alchemy_engine_arguments == {"foo": "bar", "num": 123, "bool": True, "float": 1.23}
+
+
+def test_generate_middleware_kwargs():
+
+    kwargs_defaults = generate_middleware_kwargs(TEST_DATABASE_URL, True, None, None, None)
+    assert isinstance(kwargs_defaults, dict)
+    assert kwargs_defaults["db_url"] == TEST_DATABASE_URL
+    assert kwargs_defaults["commit_on_exit"] is True
+    assert "engine_args" not in kwargs_defaults
+
+    kwargs_values = generate_middleware_kwargs(
+        TEST_DATABASE_URL, False, {"foo": "bar", "num": 123, "bool": True}, "resource_id", 456
+    )
+    assert isinstance(kwargs_values, dict)
+    assert kwargs_values["db_url"] == TEST_DATABASE_URL
+    assert kwargs_values["commit_on_exit"] is False
+    assert kwargs_values["engine_args"] == {"pool_recycle": 456, "foo": "bar", "num": 123, "bool": True}

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -31,7 +31,7 @@ def test_settings_defaults(preserved_environment):
     settings = CommonSettings()
 
     assert settings.enable_notifications is None
-    assert settings.sql_alchemy_engine_arguments is None
+    assert settings.sqlalchemy_engine_arguments is None
     assert settings.database_url == PostgresDsn(TEST_DATABASE_URL)
     assert isinstance(settings.db_middleware_kwargs, dict)
 
@@ -42,10 +42,10 @@ def test_settings_engine_args(preserved_environment):
     # Reset config
     remove_mandatory_settings()
     os.environ["DATABASE_URL"] = TEST_DATABASE_URL
-    os.environ["SQL_ALCHEMY_ENGINE_ARGUMENTS"] = '{"foo": "bar", "num": 123, "bool": true, "float": 1.23}'
+    os.environ["SQLALCHEMY_ENGINE_ARGUMENTS"] = '{"foo": "bar", "num": 123, "bool": true, "float": 1.23}'
 
     settings = CommonSettings()
-    assert settings.sql_alchemy_engine_arguments == {"foo": "bar", "num": 123, "bool": True, "float": 1.23}
+    assert settings.sqlalchemy_engine_arguments == {"foo": "bar", "num": 123, "bool": True, "float": 1.23}
 
 
 def test_generate_middleware_kwargs():


### PR DESCRIPTION
* Added a new `sql_alchemy_engine_arguments` setting that can allow `create_engine` arguments to be set in the environment. Should allow expanding pool_size / max_overflow for deployments requiring a lot of requests.