### PR TITLE
Added python requirement line to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "envoy"
 version = "0.13.1"
+requires-python = ">=3.9,<4.0"
 dependencies = [
     "fastapi>=0.94.1",
     "sqlalchemy>=2.0.0",


### PR DESCRIPTION
This helps with package management tools such as poetry, which was refusing to install the project without it being specified. The version 3.9 base is what envoy-schema uses as its base version, so should not cause any clashes with other packages until next round of package updates. If something clashes then this my need to updated or the dependency specified more tightly

Suggestion: The project adopts a package management solution (e.g. uv, poetry) and utilises lock files to help with future dependency resolutions.