### PR TITLE
Removed deprecated ENVOY_SCHEMA_PRIVATE_KEY secret

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.ENVOY_SCHEMA_PRIVATE_KEY }}'
           sudo apt install -y postgresql
           pip install .[dev,test]
 
@@ -40,8 +38,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.ENVOY_SCHEMA_PRIVATE_KEY }}'
           sudo apt install -y postgresql
           pip install .[dev,test]
 

--- a/.github/workflows/linttest.yml
+++ b/.github/workflows/linttest.yml
@@ -67,8 +67,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.ENVOY_SCHEMA_PRIVATE_KEY }}'
           pip install .[dev]
 
       - name: Add mypy annotator
@@ -106,8 +104,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.ENVOY_SCHEMA_PRIVATE_KEY }}'
           sudo apt install -y postgresql
           pip install .[test]
 
@@ -133,8 +129,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< '${{ secrets.ENVOY_SCHEMA_PRIVATE_KEY }}'
           sudo apt install -y postgresql
           pip install .[test]
 


### PR DESCRIPTION
The need for `ENVOY_SCHEMA_PRIVATE_KEY` has long since been redundant since it was made public and pushed to pypi. This PR removes it from the github actions