### PR TITLE
Simplified alembic migration use for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,4 +98,4 @@ test = [
 ]
 
 [tool.setuptools.package-data]
-"envoy" = ["py.typed"]
+"envoy" = ["py.typed", "server/alembic.ini"]

--- a/src/envoy/server/alembic/__init__.py
+++ b/src/envoy/server/alembic/__init__.py
@@ -1,0 +1,25 @@
+"""DB versions - allows any downstream dependencies to use these migrations by making it all relative.
+
+Originally sourced from https://stackoverflow.com/a/74875605"""
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+# Ensure all the paths are absolute references and can be accessed from within this project or in downstream projects
+ROOT_PATH = Path(__file__).parent.parent
+ALEMBIC_CFG = Config(ROOT_PATH / "alembic.ini")
+ALEMBIC_CFG.set_main_option("script_location", str((ROOT_PATH / "alembic").resolve()))
+
+
+def current(verbose=False):
+    command.current(ALEMBIC_CFG, verbose=verbose)
+
+
+def upgrade(revision="head"):
+    command.upgrade(ALEMBIC_CFG, revision)
+
+
+def downgrade(revision):
+    command.downgrade(ALEMBIC_CFG, revision)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
-import glob
 import os
 from decimal import Decimal
 from typing import Generator
 
-import alembic.config
 import pytest
 from assertical.fixtures.environment import environment_snapshot
 from assertical.fixtures.postgres import generate_async_conn_str_from_connection

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from assertical.fixtures.environment import environment_snapshot
 from assertical.fixtures.postgres import generate_async_conn_str_from_connection
 from psycopg import Connection
 
+from envoy.server.alembic import upgrade
 from tests.integration.conftest import READONLY_USER_KEY_1, READONLY_USER_KEY_2, READONLY_USER_NAME
 from tests.unit.jwt import DEFAULT_CLIENT_ID, DEFAULT_DATABASE_RESOURCE_ID, DEFAULT_ISSUER, DEFAULT_TENANT_ID
 
@@ -78,31 +79,8 @@ def pg_empty_config(
     else:
         os.environ["ALLOW_DEVICE_REGISTRATION"] = "True"
 
-    # we want alembic to run from the server directory but to revert back afterwards
-    cwd = os.getcwd()
-    try:
-        os.chdir("./src/envoy/server/")
-
-        # Create migrations (if none are there)
-        if len(glob.glob("alembic/versions/*.py")) == 0:
-            alembicArgs = [
-                "--raiseerr",
-                "revision",
-                "--autogenerate",
-                "-m",
-                "init",
-            ]
-            alembic.config.main(argv=alembicArgs)
-
-        # Apply migrations
-        alembicArgs = [
-            "--raiseerr",
-            "upgrade",
-            "head",
-        ]
-        alembic.config.main(argv=alembicArgs)
-    finally:
-        os.chdir(cwd)
+    # This will install all of the alembic migrations - DB is accessed from the DATABASE_URL env variable
+    upgrade()
 
     yield postgresql
 


### PR DESCRIPTION
* Migrations now can be run in tests by just importing the "upgrade" function


This will work in any downstream project that uses envoy as a dependency (if there is a desire to recreate the envoy db schema).