### PR TITLE
Fix 500 response on DERControlList endpoint

### DIFF
--- a/src/envoy/server/mapper/csip_aus/doe.py
+++ b/src/envoy/server/mapper/csip_aus/doe.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from enum import IntEnum, auto
 from typing import Optional, Sequence, Union
@@ -53,7 +53,8 @@ class DERControlMapper:
         """Creates a csip aus compliant DERControlResponse from the specific doe. Needs to know current datetime
         in order to determine if the control is active or scheduled"""
 
-        is_intersecting_now = doe.start_time <= now and doe.end_time > now
+        # end_time is not populated in the upstream query, so use duration instead.
+        is_intersecting_now = doe.start_time <= now and doe.start_time + timedelta(seconds=doe.duration_seconds) > now
         event_status: int
         event_status_time: datetime
         if isinstance(doe, ArchiveDynamicOperatingEnvelope) and doe.deleted_time is not None:


### PR DESCRIPTION
DERControlList endpoints are currently returning a 500 with the error:

```
envoy-1  | [2025-05-26 02:34:53 +0000] [10] [ERROR] Exception in ASGI application
envoy-1  |   + Exception Group Traceback (most recent call last):
envoy-1  |   |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 76, in collapse_excgroups
envoy-1  |   |     yield
envoy-1  |   |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 178, in __call__
envoy-1  |   |     async with anyio.create_task_group() as task_group:
envoy-1  |   |   File "/usr/local/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
envoy-1  |   |     raise BaseExceptionGroup(
envoy-1  |   | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
envoy-1  |   +-+---------------- 1 ----------------
envoy-1  |     | Traceback (most recent call last):
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
envoy-1  |     |     result = await app(  # type: ignore[func-returns-value]
envoy-1  |     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
envoy-1  |     |     return await self.app(scope, receive, send)
envoy-1  |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
envoy-1  |     |     await super().__call__(scope, receive, send)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 112, in __call__
envoy-1  |     |     await self.middleware_stack(scope, receive, send)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in __call__
envoy-1  |     |     raise exc
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
envoy-1  |     |     await self.app(scope, receive, _send)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 177, in __call__
envoy-1  |     |     with recv_stream, send_stream, collapse_excgroups():
envoy-1  |     |   File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
envoy-1  |     |     self.gen.throw(typ, value, traceback)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
envoy-1  |     |     raise exc
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 179, in __call__
envoy-1  |     |     response = await self.dispatch_func(request, call_next)
envoy-1  |     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/fastapi_async_sqlalchemy/middleware.py", line 55, in dispatch
envoy-1  |     |     return await call_next(request)
envoy-1  |     |            ^^^^^^^^^^^^^^^^^^^^^^^^
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 154, in call_next
envoy-1  |     |     raise app_exc
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 141, in coro
envoy-1  |     |     await self.app(scope, receive_or_disconnect, send_no_error)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
envoy-1  |     |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
envoy-1  |     |     raise exc
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
envoy-1  |     |     await app(scope, receive, sender)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 715, in __call__
envoy-1  |     |     await self.middleware_stack(scope, receive, send)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 735, in app
envoy-1  |     |     await route.handle(scope, receive, send)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
envoy-1  |     |     await self.app(scope, receive, send)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
envoy-1  |     |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
envoy-1  |     |     raise exc
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
envoy-1  |     |     await app(scope, receive, sender)
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
envoy-1  |     |     response = await f(request)
envoy-1  |     |                ^^^^^^^^^^^^^^^^
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 301, in app
envoy-1  |     |     raw_response = await run_endpoint_function(
envoy-1  |     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
envoy-1  |     |   File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 212, in run_endpoint_function
envoy-1  |     |     return await dependant.call(**values)
envoy-1  |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
envoy-1  |     |   File "/src/envoy/src/envoy/server/api/sep2/derp.py", line 114, in get_dercontrol_list
envoy-1  |     |     derc_list = await DERControlManager.fetch_doe_controls_for_scope(
envoy-1  |     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
envoy-1  |     |   File "/src/envoy/src/envoy/server/manager/derp.py", line 163, in fetch_doe_controls_for_scope
envoy-1  |     |     return DERControlMapper.map_to_list_response(
envoy-1  |     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
envoy-1  |     |   File "/src/envoy/src/envoy/server/mapper/csip_aus/doe.py", line 221, in map_to_list_response
envoy-1  |     |     "DERControl": [
envoy-1  |     |                   ^
envoy-1  |     |   File "/src/envoy/src/envoy/server/mapper/csip_aus/doe.py", line 222, in <listcomp>
envoy-1  |     |     DERControlMapper.map_to_response(
envoy-1  |     |   File "/src/envoy/src/envoy/server/mapper/csip_aus/doe.py", line 56, in map_to_response
envoy-1  |     |     is_intersecting_now = doe.start_time <= now and doe.end_time > now
envoy-1  |     |                                                     ^^^^^^^^^^^^^^^^^^
envoy-1  |     | TypeError: '>' not supported between instances of 'NoneType' and 'datetime.datetime'
```

This is due to the fact that the end time isn't populated by the upstream query. There is probably a better fix than this, but I needed a tactical fix for this for now, so can serve as a starting point for discussion.