### PR TITLE
Added --ignore-installed to pip install on coverage action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt install -y postgresql
-          pip install .[dev,test]
+          pip install --ignore-installed .[dev,test]
 
       - name: Coverage (source branch)
         run: |
@@ -39,7 +39,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt install -y postgresql
-          pip install .[dev,test]
+          pip install --ignore-installed .[dev,test]
 
       - name: Coverage (target branch)
         run: |


### PR DESCRIPTION
Had an issue where I had changed the dependencies between the target and source branches and the dependencies from the source branch were being used, incompatible with the target branch (namely our envoy-schema fork) causing a false negative. May stop any problems that come up in future. 