### PR TITLE
Added support for uppercase lfdis

### DIFF
--- a/src/envoy/server/manager/end_device.py
+++ b/src/envoy/server/manager/end_device.py
@@ -157,6 +157,11 @@ class EndDeviceManager:
         raise UnableToGenerateIdError(f"Unable to generate a unique sfdi within {MAX_ATTEMPTS} attempts. Failing.")
 
     @staticmethod
+    def lfdi_matches(a: Optional[str], b: Optional[str]) -> bool:
+        """Case insensitive matching of LFDIs"""
+        return (None if a is None else a.lower()) == (None if b is None else b.lower())
+
+    @staticmethod
     async def add_or_update_enddevice_for_scope(
         session: AsyncSession, scope: UnregisteredRequestScope, end_device: EndDeviceRequest
     ) -> int:
@@ -172,7 +177,7 @@ class EndDeviceManager:
             # In this case - the client is restricted to ONLY interact with the site with the same sfdi/lfdi
             if end_device.sFDI != scope.sfdi:
                 raise ForbiddenError(f"sfdi mismatch. POST body: {end_device.sFDI} cert: {scope.sfdi}")
-            if end_device.lFDI != scope.lfdi:
+            if not EndDeviceManager.lfdi_matches(end_device.lFDI, scope.lfdi):
                 raise ForbiddenError(f"lfdi mismatch. POST body: '{end_device.lFDI}' cert: '{scope.lfdi}'")
 
         # Generate the sfdi if required (never do this for device certs)

--- a/src/envoy/server/manager/metering.py
+++ b/src/envoy/server/manager/metering.py
@@ -41,14 +41,15 @@ class MirrorMeteringManager:
         or updated mup. Raises InvalidIdError if the underlying site cannot be fetched
 
         Will commit the underlying session on success"""
+
+        mup_lfdi = mup.deviceLFDI.lower()  # Always compare on lowercase
+
         if scope.source == CertificateType.DEVICE_CERTIFICATE:
             # device certs are limited to the LFDI of the device cert
-            if mup.deviceLFDI != scope.lfdi:
+            if mup_lfdi != scope.lfdi:
                 raise ForbiddenError(f"deviceLFDI '{mup.deviceLFDI}' doesn't match client certificate '{scope.lfdi}'")
 
-        site = await select_single_site_with_lfdi(
-            session=session, lfdi=mup.deviceLFDI, aggregator_id=scope.aggregator_id
-        )
+        site = await select_single_site_with_lfdi(session=session, lfdi=mup_lfdi, aggregator_id=scope.aggregator_id)
         if site is None:
             raise InvalidIdError(f"deviceLFDI {mup.deviceLFDI} doesn't match a known site.")
 

--- a/src/envoy/server/mapper/sep2/end_device.py
+++ b/src/envoy/server/mapper/sep2/end_device.py
@@ -13,6 +13,7 @@ from envoy_schema.server.schema.sep2.identification import Link, ListLink
 from envoy_schema.server.schema.sep2.types import SubscribableType
 
 from envoy.server.crud.common import sum_digits
+from envoy.server.exception import InvalidMappingError
 from envoy.server.mapper.common import generate_href, parse_device_category
 from envoy.server.model.site import Site
 from envoy.server.request_scope import BaseRequestScope
@@ -51,8 +52,10 @@ class EndDeviceMapper:
     def map_from_request(
         end_device: EndDeviceRequest, aggregator_id: int, changed_time: datetime, registration_pin: int
     ) -> Site:
+        if not end_device.lFDI:
+            raise InvalidMappingError("No lfdi was specified for EndDevice.")
         return Site(
-            lfdi=end_device.lFDI,
+            lfdi=end_device.lFDI.lower(),  # Always store it lower case
             sfdi=end_device.sFDI,
             registration_pin=registration_pin,
             changed_time=changed_time,

--- a/src/envoy/server/request_scope.py
+++ b/src/envoy/server/request_scope.py
@@ -26,7 +26,7 @@ class BaseRequestScope:
     """The common fields for ALL request scopes. A request scope is a narrowed form of auth that outline very
     precise restrictions on what a request can interact with. A scope is created from a RawRequestClaims."""
 
-    lfdi: str  # The lfdi associated with the aggregator/site ID (sourced from the client TLS certificate)
+    lfdi: str  # The lowercase lfdi associated with the aggregator/site ID (sourced from the client TLS certificate)
     sfdi: int  # The sfdi associated with the aggregator/site ID (sourced from the client TLS certificate)
     href_prefix: Optional[str]  # If set - all outgoing href's should be prefixed with this value
     iana_pen: int  # The IANA Private Enterprise Number of the org hosting this utility server instance

--- a/tests/integration/func_sets/test_end_device.py
+++ b/tests/integration/func_sets/test_end_device.py
@@ -334,9 +334,9 @@ async def test_create_end_device_shinehub(client: AsyncClient, edev_base_uri: st
 async def test_create_end_device_specified_sfdi(client: AsyncClient, edev_base_uri: str):
     """When creating an end_device check to see if it persists and is correctly assigned to the aggregator"""
 
-    insert_request: EndDeviceRequest = generate_class_instance(EndDeviceRequest)
-    insert_request.postRate = 123
-    insert_request.deviceCategory = "{0:x}".format(int(DeviceCategory.HOT_TUB))
+    insert_request: EndDeviceRequest = generate_class_instance(
+        EndDeviceRequest, postRate=123, deviceCategory="{0:x}".format(int(DeviceCategory.HOT_TUB)), lFDI="123ABCdef"
+    )
     response = await client.post(
         edev_base_uri,
         headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
@@ -355,7 +355,7 @@ async def test_create_end_device_specified_sfdi(client: AsyncClient, edev_base_u
     assert_nowish(parsed_response.changedTime)
     assert parsed_response.href == inserted_href
     assert parsed_response.enabled == 1
-    assert parsed_response.lFDI == insert_request.lFDI
+    assert parsed_response.lFDI == insert_request.lFDI.lower()
     assert parsed_response.sFDI == insert_request.sFDI
     assert parsed_response.deviceCategory == insert_request.deviceCategory
 
@@ -580,6 +580,7 @@ async def test_update_end_device_bad_device_category(
     [
         (UNREGISTERED_CERT.decode(), UNREGISTERED_CERT_LFDI, int(UNREGISTERED_CERT_SFDI), HTTPStatus.CREATED),
         (UNREGISTERED_CERT_LFDI, UNREGISTERED_CERT_LFDI, int(UNREGISTERED_CERT_SFDI), HTTPStatus.CREATED),
+        (UNREGISTERED_CERT_LFDI, UNREGISTERED_CERT_LFDI.upper(), int(UNREGISTERED_CERT_SFDI), HTTPStatus.CREATED),
         # Trying bad combos of lfdi/sfdi
         (UNREGISTERED_CERT_LFDI, REGISTERED_CERT_LFDI, int(UNREGISTERED_CERT_SFDI), HTTPStatus.FORBIDDEN),
         (UNREGISTERED_CERT_LFDI, UNREGISTERED_CERT_LFDI, int(REGISTERED_CERT_SFDI), HTTPStatus.FORBIDDEN),


### PR DESCRIPTION
* EndDevice, MirrorUsagePoint now properly handles lfdi in a case insensitive manner
* Storage in the DB will forced to lower case