### PR TITLE
feat: aggregator admin create and update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "taskiq!=0.11.5,!=0.11.6",      # Known compatibiity issue with pydantic
     "taskiq-aio-pika",
     "parse",
-    "envoy_schema==0.23.0",
+    "envoy_schema==0.24.0",
     "intervaltree",
 ]
 

--- a/src/envoy/admin/crud/aggregator.py
+++ b/src/envoy/admin/crud/aggregator.py
@@ -34,6 +34,25 @@ async def select_all_aggregators(session: AsyncSession, start: int, limit: int) 
     return resp.scalars().all()
 
 
+async def insert_single_aggregator(session: AsyncSession, aggregator: Aggregator) -> None:
+    """Inserts a single aggregator entry into the DB. Returns None"""
+    if aggregator.created_time:
+        del aggregator.created_time
+    session.add(aggregator)
+
+
+async def update_single_aggregator(session: AsyncSession, updated_aggregator: Aggregator) -> None:
+    """Updates a single existing aggregator entry in the DB."""
+
+    resp = await session.execute(
+        sa.select(Aggregator).where(Aggregator.aggregator_id == updated_aggregator.aggregator_id)
+    )
+    aggregator = resp.scalar_one()
+
+    aggregator.changed_time = updated_aggregator.changed_time
+    aggregator.name = updated_aggregator.name
+
+
 async def assign_many_certificates(session: AsyncSession, aggregator_id: int, certificate_ids: Iterable[int]) -> None:
     """Assigns certificates to an aggregator.
 

--- a/src/envoy/admin/manager/aggregator.py
+++ b/src/envoy/admin/manager/aggregator.py
@@ -1,20 +1,22 @@
 from typing import Optional
 
-from envoy_schema.admin.schema.aggregator import AggregatorPageResponse, AggregatorResponse
+from envoy_schema.admin.schema.aggregator import AggregatorPageResponse, AggregatorResponse, AggregatorRequest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from envoy.admin.crud.aggregator import count_all_aggregators, select_all_aggregators
-from envoy.admin.mapper.aggregator import AggregatorMapper
+from envoy.admin import crud
+from envoy.admin import mapper
 from envoy.server.crud.aggregator import select_aggregator
+from envoy.server.manager.time import utc_now
+from envoy.server import exception
 
 
 class AggregatorManager:
     @staticmethod
     async def fetch_many_aggregators(session: AsyncSession, start: int, limit: int) -> AggregatorPageResponse:
         """Select many aggregators from the DB and map to a list of AggregatorResponse objects"""
-        agg_list = await select_all_aggregators(session, start, limit)
-        agg_count = await count_all_aggregators(session)
-        return AggregatorMapper.map_to_page_response(
+        agg_list = await crud.aggregator.select_all_aggregators(session, start, limit)
+        agg_count = await crud.aggregator.count_all_aggregators(session)
+        return mapper.AggregatorMapper.map_to_page_response(
             total_count=agg_count, start=start, limit=limit, aggregators=agg_list
         )
 
@@ -25,4 +27,30 @@ class AggregatorManager:
         aggregator = await select_aggregator(session, aggregator_id)
         if aggregator is None:
             return None
-        return AggregatorMapper.map_to_response(aggregator)
+        return mapper.AggregatorMapper.map_to_response(aggregator)
+
+    @staticmethod
+    async def add_new_aggregator(session: AsyncSession, aggregator: AggregatorRequest) -> int:
+        """Map an AggregatorRequest object to an Aggregator model and insert into DB. Return the aggregator_id only."""
+
+        changed_time = utc_now()
+        agg_model = mapper.AggregatorMapper.map_from_request(changed_time, aggregator)
+        await crud.aggregator.insert_single_aggregator(session, agg_model)
+        await session.commit()
+        return agg_model.aggregator_id
+
+    @staticmethod
+    async def update_existing_aggregator(
+        session: AsyncSession,
+        aggregator_id: int,
+        aggregator: AggregatorRequest,
+    ) -> None:
+        """Map a AggregatorRequest object to a Aggregator model and update DB entry."""
+
+        if not await select_aggregator(session, aggregator_id):
+            raise exception.NotFoundError(f"Aggregator with id {aggregator_id} not found")
+        changed_time = utc_now()
+        agg_model = mapper.AggregatorMapper.map_from_request(changed_time, aggregator)
+        agg_model.aggregator_id = aggregator_id
+        await crud.aggregator.update_single_aggregator(session, agg_model)
+        await session.commit()

--- a/src/envoy/admin/mapper/aggregator.py
+++ b/src/envoy/admin/mapper/aggregator.py
@@ -1,6 +1,13 @@
 from typing import Iterable
 
-from envoy_schema.admin.schema.aggregator import AggregatorDomain, AggregatorPageResponse, AggregatorResponse
+import datetime as dt
+
+from envoy_schema.admin.schema.aggregator import (
+    AggregatorDomain,
+    AggregatorPageResponse,
+    AggregatorResponse,
+    AggregatorRequest,
+)
 
 from envoy.server.model.aggregator import Aggregator
 
@@ -33,4 +40,11 @@ class AggregatorMapper:
             start=start,
             limit=limit,
             aggregators=[AggregatorMapper.map_to_response(a) for a in aggregators],
+        )
+
+    @staticmethod
+    def map_from_request(changed_time: dt.datetime, aggregator: AggregatorRequest) -> Aggregator:
+        return Aggregator(
+            name=aggregator.name,
+            changed_time=changed_time,
         )

--- a/tests/integration/admin/test_aggregator.py
+++ b/tests/integration/admin/test_aggregator.py
@@ -299,9 +299,7 @@ async def test_create_aggregator(admin_client_auth: AsyncClient) -> None:
 @pytest.mark.anyio
 async def test_update_aggregator(admin_client_auth: AsyncClient) -> None:
     aggregator = generate_class_instance(AggregatorRequest)
-    resp = await admin_client_auth.put(
-        uri.AggregatorUri.format(aggregator_id=1), content=aggregator.model_dump_json()
-    )
+    resp = await admin_client_auth.put(uri.AggregatorUri.format(aggregator_id=1), content=aggregator.model_dump_json())
 
     assert resp.status_code == HTTPStatus.OK
 

--- a/tests/integration/admin/test_aggregator.py
+++ b/tests/integration/admin/test_aggregator.py
@@ -7,7 +7,13 @@ import pytest
 import psycopg
 import sqlalchemy as sa
 from assertical.fixtures.postgres import generate_async_session
-from envoy_schema.admin.schema.aggregator import AggregatorResponse, AggregatorPageResponse, AggregatorDomain
+from assertical.fake.generator import generate_class_instance
+from envoy_schema.admin.schema.aggregator import (
+    AggregatorResponse,
+    AggregatorPageResponse,
+    AggregatorDomain,
+    AggregatorRequest,
+)
 from envoy_schema.admin.schema.certificate import (
     CertificateResponse,
     CertificatePageResponse,
@@ -274,3 +280,37 @@ async def test_delete_aggregator_certificate_assignments(
     certs = cert_page.certificates
 
     assert [c.certificate_id for c in certs] == expected_ids
+
+
+@pytest.mark.anyio
+async def test_create_aggregator(admin_client_auth: AsyncClient) -> None:
+    aggregator = generate_class_instance(AggregatorRequest)
+    resp = await admin_client_auth.post(uri.AggregatorListUri, content=aggregator.model_dump_json())
+
+    assert resp.status_code == HTTPStatus.CREATED
+
+    # Confirm location header set correctly
+    [agg_list_uri, aggregator_id] = resp.headers["Location"].rsplit("/", maxsplit=1)
+    assert agg_list_uri == uri.AggregatorListUri
+    assert int(aggregator_id)
+    assert int(aggregator_id) > 3
+
+
+@pytest.mark.anyio
+async def test_update_aggregator(admin_client_auth: AsyncClient) -> None:
+    aggregator = generate_class_instance(AggregatorRequest)
+    resp = await admin_client_auth.put(
+        uri.AggregatorUri.format(aggregator_id=1), content=aggregator.model_dump_json()
+    )
+
+    assert resp.status_code == HTTPStatus.OK
+
+
+@pytest.mark.anyio
+async def test_update_aggregator_invalid_id(admin_client_auth: AsyncClient) -> None:
+    aggregator = generate_class_instance(AggregatorRequest)
+    resp = await admin_client_auth.put(
+        uri.AggregatorUri.format(aggregator_id=1111), content=aggregator.model_dump_json()
+    )
+
+    assert resp.status_code == HTTPStatus.NOT_FOUND

--- a/tests/unit/admin/manager/test_aggregator.py
+++ b/tests/unit/admin/manager/test_aggregator.py
@@ -1,0 +1,59 @@
+import pytest
+import pytest_mock
+from envoy_schema.admin.schema.aggregator import AggregatorRequest
+
+from envoy.admin import manager
+from envoy.server import exception
+
+
+@pytest.fixture
+def mock_crud(mocker: pytest_mock.MockerFixture) -> pytest_mock.AsyncMockType:
+    return mocker.patch("envoy.admin.crud.aggregator", new=mocker.AsyncMock())
+
+
+@pytest.fixture
+def mock_select_aggregator(mocker: pytest_mock.MockerFixture) -> pytest_mock.AsyncMockType:
+    return mocker.patch("envoy.admin.manager.aggregator.select_aggregator", new=mocker.AsyncMock())
+
+
+@pytest.fixture
+def mock_mapper(mocker: pytest_mock.MockerFixture) -> pytest_mock.AsyncMockType:
+    return mocker.patch("envoy.admin.mapper.AggregatorMapper", new=mocker.AsyncMock())
+
+
+@pytest.mark.anyio
+async def test_add_new_aggregator(mocker: pytest_mock.MockerFixture, mock_crud: pytest_mock.AsyncMockType) -> None:
+    """Confirm correct calls for add_new_aggregator() method"""
+    async with mocker.AsyncMock() as session:
+        aggregator = AggregatorRequest(name="some new aggregator")
+        await manager.AggregatorManager.add_new_aggregator(session, aggregator)
+        mock_crud.insert_single_aggregator.assert_called_once()
+        session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_update_existing_aggregator(
+    mocker: pytest_mock.MockerFixture,
+    mock_crud: pytest_mock.AsyncMockType,
+    mock_select_aggregator: pytest_mock.AsyncMockType,
+) -> None:
+    """Confirm correct calls for update_existing_aggregator() method"""
+    async with mocker.AsyncMock() as session:
+        aggregator = AggregatorRequest(name="renamed aggregator")
+        await manager.AggregatorManager.update_existing_aggregator(session, 1111, aggregator)
+        mock_select_aggregator.assert_called_once()
+        mock_crud.update_single_aggregator.assert_called_once()
+        session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_update_existing_aggregator_non_aggregator(
+    mocker: pytest_mock.MockerFixture,
+    mock_select_aggregator: pytest_mock.AsyncMockType,
+) -> None:
+    """Confirm update_existing_aggregator() method raises for non-existing aggregator"""
+    async with mocker.AsyncMock() as session:
+        aggregator = AggregatorRequest(name="won't be renamed aggregator")
+        mock_select_aggregator.return_value = None
+        with pytest.raises(exception.NotFoundError):
+            await manager.AggregatorManager.update_existing_aggregator(session, 1111, aggregator)

--- a/tests/unit/admin/mapper/test_aggregator.py
+++ b/tests/unit/admin/mapper/test_aggregator.py
@@ -1,11 +1,12 @@
 from itertools import product
+import datetime as dt
 
 import pytest
 from assertical.asserts.generator import assert_class_instance_equality
 from assertical.asserts.type import assert_list_type
 from assertical.fake.generator import generate_class_instance
 from envoy_schema.admin.schema.aggregator import AggregatorDomain as AggregatorDomainResponse
-from envoy_schema.admin.schema.aggregator import AggregatorPageResponse, AggregatorResponse
+from envoy_schema.admin.schema.aggregator import AggregatorPageResponse, AggregatorResponse, AggregatorRequest
 
 from envoy.admin.mapper.aggregator import AggregatorMapper
 from envoy.server.model.aggregator import Aggregator
@@ -49,3 +50,15 @@ def test_aggregator_to_page_response():
     assert mdl.limit == limit
     assert mdl.start == start
     assert mdl.total_count == total_count
+
+
+def test_aggregator_from_request() -> None:
+    """Tests mapping from a request"""
+    req = AggregatorRequest(name="Some new aggregator")
+
+    change_time = dt.datetime(1234, 5, 6, 7, 8, 9, tzinfo=dt.timezone.utc)
+    agg = AggregatorMapper.map_from_request(change_time, req)
+
+    assert isinstance(agg, Aggregator)
+    assert agg.name == "Some new aggregator"
+    assert agg.changed_time == change_time


### PR DESCRIPTION
Enables creation and updating of aggregators via the admin api. Didn't get to DELETE, due to the time required to understand the need to archive vs straight delete for foreign objects.

envoy-schema version pre-emptively selected based on https://github.com/bsgip/envoy-schema/pull/44 aligning with this PR. 