### PR TITLE
Expanded status health endpoints

### DIFF
--- a/src/envoy/admin/api/__init__.py
+++ b/src/envoy/admin/api/__init__.py
@@ -6,6 +6,7 @@ from envoy.admin.api.billing import router as billing_router
 from envoy.admin.api.certificate import router as certificate_router
 from envoy.admin.api.config import router as config_router
 from envoy.admin.api.doe import router as doe_router
+from envoy.admin.api.health import router as health_router
 from envoy.admin.api.log import router as log_router
 from envoy.admin.api.pricing import router as price_router
 from envoy.admin.api.site import router as site_router
@@ -25,3 +26,5 @@ routers = [
     site_reading_router,
     certificate_router,
 ]
+
+unsecured_routers = [health_router]

--- a/src/envoy/admin/api/health.py
+++ b/src/envoy/admin/api/health.py
@@ -1,0 +1,39 @@
+import logging
+from http import HTTPStatus
+
+from fastapi import APIRouter, Response
+from fastapi_async_sqlalchemy import db
+
+from envoy.server.manager.health import HealthManager
+
+logger = logging.getLogger(__name__)
+
+
+router = APIRouter()
+
+HEALTH_URI = "/status/health"
+
+
+@router.head(HEALTH_URI)
+@router.get(HEALTH_URI, status_code=HTTPStatus.OK)
+async def get_health(check_data: bool = True) -> Response:
+    """Responds with a HTTP 200 if the server diagnostics report everything is OK. HTTP 500 otherwise.
+
+    Response will be a plaintext encoding of the passing/failing health checks
+
+    Returns:
+        fastapi.Response object.
+    """
+
+    check = await HealthManager.run_health_check(db.session)
+    headers = {"Content-Type": "text/plain"}
+    content = str(check)
+
+    if not check.database_connectivity:
+        status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    elif check_data and not check.database_has_data:
+        status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    else:
+        status_code = HTTPStatus.OK
+
+    return Response(content=content, status_code=status_code, headers=headers)

--- a/src/envoy/server/api/unsecured/health.py
+++ b/src/envoy/server/api/unsecured/health.py
@@ -19,7 +19,7 @@ HEALTH_DYNAMIC_PRICE_URI = "/status/dynamicprices"
 
 @router.head(HEALTH_URI)
 @router.get(HEALTH_URI, status_code=HTTPStatus.OK)
-async def get_health() -> Response:
+async def get_health(check_data: bool = True) -> Response:
     """Responds with a HTTP 200 if the server diagnostics report everything is OK. HTTP 500 otherwise.
 
     Response will be a plaintext encoding of the passing/failing health checks
@@ -34,7 +34,7 @@ async def get_health() -> Response:
 
     if not check.database_connectivity:
         status_code = HTTPStatus.INTERNAL_SERVER_ERROR
-    elif not check.database_has_data:
+    elif check_data and not check.database_has_data:
         status_code = HTTPStatus.INTERNAL_SERVER_ERROR
     else:
         status_code = HTTPStatus.OK

--- a/tests/integration/admin/test_health.py
+++ b/tests/integration/admin/test_health.py
@@ -1,0 +1,52 @@
+from http import HTTPStatus
+
+import pytest
+from httpx import AsyncClient
+
+from envoy.admin.api.health import HEALTH_URI
+from tests.integration.response import read_response_body_string
+
+
+@pytest.mark.anyio
+async def test_get_health_unauth(admin_client_unauth: AsyncClient):
+    """Checks HEALTH_URI returns HTTP 200 for all requests (ignoring auth)"""
+
+    response = await admin_client_unauth.request(method="GET", url=HEALTH_URI)
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
+async def test_get_health_auth(admin_client_auth: AsyncClient):
+    """Checks HEALTH_URI returns HTTP 200 for all requests (with auth)"""
+
+    response = await admin_client_auth.request(method="GET", url=HEALTH_URI)
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
+async def test_get_health_readonly_auth(admin_client_readonly_auth: AsyncClient):
+    """Checks HEALTH_URI returns HTTP 200 for all requests (with readonly auth)"""
+
+    response = await admin_client_readonly_auth.request(method="GET", url=HEALTH_URI)
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
+async def test_get_health_detects_no_data(admin_client_empty_db: AsyncClient):
+    """Checks the health check will fail if the DB is empty"""
+
+    response = await admin_client_empty_db.request(method="GET", url=HEALTH_URI)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
+async def test_get_health_detects_no_data_not_checking(admin_client_empty_db: AsyncClient):
+    """Checks the health check will pass if the DB is empty and we aren't checking for data"""
+
+    response = await admin_client_empty_db.request(method="GET", url=HEALTH_URI + "?check_data=false")
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -58,6 +58,19 @@ def valid_headers_with_azure_ad():
 
 
 @pytest.fixture(scope="function")
+async def admin_client_empty_db(pg_empty_config: Connection):
+    """Creates an AsyncClient for a test that is configured to talk to the admin server app (base config not loaded)"""
+    settings = admin_gen_settings()
+    basic_auth = (settings.admin_username, settings.admin_password)
+
+    # We want a new app instance for every test - otherwise connection pools get shared and we hit problems
+    # when trying to run multiple tests sequentially
+    app = admin_gen_app(settings)
+    async with start_app_with_client(app, client_auth=basic_auth) as c:
+        yield c
+
+
+@pytest.fixture(scope="function")
 async def admin_client_auth(pg_base_config: Connection):
     """Creates an AsyncClient for a test that is configured to talk to the admin server app"""
     settings = admin_gen_settings()

--- a/tests/integration/general/test_admin.py
+++ b/tests/integration/general/test_admin.py
@@ -5,10 +5,11 @@ from http import HTTPStatus
 import pytest
 from httpx import AsyncClient
 
+from envoy.admin.api.health import HEALTH_URI
 from tests.integration.http import HTTPMethod
 from tests.integration.response import assert_response_header
 
-NO_AUTH_ROUTES = ["/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc"]
+NO_AUTH_ROUTES = ["/openapi.json", "/docs", "/docs/oauth2-redirect", "/redoc", HEALTH_URI]
 
 
 @pytest.mark.anyio

--- a/tests/integration/unsecured/test_health.py
+++ b/tests/integration/unsecured/test_health.py
@@ -37,6 +37,15 @@ async def test_get_health_detects_no_data(client_empty_db: AsyncClient):
 
 
 @pytest.mark.anyio
+async def test_get_health_detects_no_data_not_checking(client_empty_db: AsyncClient):
+    """Checks the health check will pass if the DB is empty and we aren't checking for data"""
+
+    response = await client_empty_db.request(method="GET", url=HEALTH_URI + "?check_data=false")
+    assert response.status_code == HTTPStatus.OK
+    assert read_response_body_string(response), "Expected a response with some content"
+
+
+@pytest.mark.anyio
 async def test_get_price_health_fails_no_future_prices(client: AsyncClient):
     """Checks HEALTH_DYNAMIC_PRICE_URI returns HTTP 500 if there are no future prices (the default for
     pg_base_config)"""


### PR DESCRIPTION
* Added health status endpoint to admin server at `/status/health`
* Made health status checking for data an optional query parameter (`check_data` which defaults to `True`)