### PR TITLE
Added support for static registration PINs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Typically settings are set by setting an environment variable with the same name
 | `default_doe_import_active_watts` | `float` | If set - the DefaultDERControl endpoint will be activated with the DOE extensions for import being set to this value (requires `default_doe_export_active_watts`)|
 | `default_doe_export_active_watts` | `float` | If set - the DefaultDERControl endpoint will be activated with the DOE extensions for export being set to this value (requires `default_doe_import_active_watts`)|
 | `allow_device_registration` | `bool` | If True - the registration workflows that enable unrecognised certs to generate/manage a single EndDevice (tied to that cert) will be enabled. Otherwise any cert will need to be registered out of band and assigned to an aggregator before connections can be made. Defaults to False|
+| `static_registration_pin` | `int` | If set - all new EndDevice registrations will have their Registration PIN set to this value (use 5 digit form). Uses a random number generator otherwise.  |
 
 
 **Additional Admin Server Settings (admin)**

--- a/src/envoy/server/manager/end_device.py
+++ b/src/envoy/server/manager/end_device.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from datetime import datetime
 from secrets import randbelow, token_bytes
 from typing import Optional, Sequence
@@ -300,6 +301,16 @@ class RegistrationManager:
     def generate_registration_pin() -> int:
         """Generates a random integer from 0 -> 99999 (5 digits) that can be used as a end device registration PIN.
         No guarantees about uniqueness are made"""
+        raw_static_pin = os.environ.get("STATIC_REGISTRATION_PIN", "")
+        if raw_static_pin:
+            try:
+                return int(raw_static_pin)
+            except ValueError as exc:
+                logger.error(
+                    f"Failure reading STATIC_REGISTRATION_PIN env variable '{raw_static_pin}' as an in", exc_info=exc
+                )
+                return 0
+
         return randbelow(MAX_REGISTRATION_PIN + 1)  # The upper bound is exclusive so +1 allows us to generate 99999
 
     @staticmethod

--- a/tests/unit/server/manager/test_end_device.py
+++ b/tests/unit/server/manager/test_end_device.py
@@ -1,3 +1,4 @@
+import os
 import unittest.mock as mock
 from datetime import datetime, timedelta
 from typing import Optional, Union
@@ -879,6 +880,24 @@ def test_generate_registration_pin():
     assert sorted(values_attempt_1) != sorted(
         values_attempt_2
     ), "If this is failing, either you're incredible unlucky or something is wrong"
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [
+        ("77441", 77441),
+        ("0", 0),
+        ("0031", 31),
+        ("04-54", 0),  # Bad value
+        ("123ab", 0),  # Bad value
+        ("12 34", 0),  # Bad value
+    ],
+)
+def test_generate_registration_pin_static(preserved_environment, env, expected):
+    os.environ["STATIC_REGISTRATION_PIN"] = env
+    assert RegistrationManager.generate_registration_pin() == expected
+    assert RegistrationManager.generate_registration_pin() == expected
+    assert isinstance(RegistrationManager.generate_registration_pin(), int)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
* Added new env config variable `STATIC_REGISTRATION_PIN` that (if set) will force all `EndDevice` registration PIN's to use this value
