### PR TITLE
Do not manipulate received LFDI during mapping

### DIFF
--- a/src/envoy/server/mapper/sep2/end_device.py
+++ b/src/envoy/server/mapper/sep2/end_device.py
@@ -55,7 +55,7 @@ class EndDeviceMapper:
         if not end_device.lFDI:
             raise InvalidMappingError("No lfdi was specified for EndDevice.")
         return Site(
-            lfdi=end_device.lFDI.lower(),  # Always store it lower case
+            lfdi=end_device.lFDI,
             sfdi=end_device.sFDI,
             registration_pin=registration_pin,
             changed_time=changed_time,

--- a/tests/unit/server/mapper/sep2/test_end_device.py
+++ b/tests/unit/server/mapper/sep2/test_end_device.py
@@ -160,6 +160,22 @@ def test_map_from_request_missing_lfdi(mock_settings: mock.MagicMock, lfdi: Opti
         EndDeviceMapper.map_from_request(end_device, 1, generate_value(datetime, 303), 12345)
 
 
+def test_map_from_request_does_not_manipulate_lfdi():
+    """Asserts that the LFDI is not manipulated during mapping."""
+    original_lfdi:str = "29830E8C4092F4A343B5427E5F4A693E12345678"
+    end_device: EndDeviceRequest = generate_class_instance(
+        EndDeviceRequest, seed=101, optional_is_none=False, lFDI=original_lfdi, deviceCategory="c0ffee"
+    )    
+    aggregator_id: int = 404
+    changed_time: datetime = generate_value(datetime, 303)
+    registration_pin: int = 505
+
+    result = EndDeviceMapper.map_from_request(end_device, aggregator_id, changed_time, registration_pin)
+    assert result is not None
+    assert isinstance(result, Site)
+    assert result.lfdi == original_lfdi
+
+
 @mock.patch("envoy.server.mapper.sep2.end_device.settings")
 def test_map_from_request(mock_settings: mock.MagicMock):
     """Simple sanity check on the mapper to ensure things don't break with a variety of values."""

--- a/tests/unit/server/mapper/sep2/test_end_device.py
+++ b/tests/unit/server/mapper/sep2/test_end_device.py
@@ -160,22 +160,6 @@ def test_map_from_request_missing_lfdi(mock_settings: mock.MagicMock, lfdi: Opti
         EndDeviceMapper.map_from_request(end_device, 1, generate_value(datetime, 303), 12345)
 
 
-def test_map_from_request_does_not_manipulate_lfdi():
-    """Asserts that the LFDI is not manipulated during mapping."""
-    original_lfdi:str = "29830E8C4092F4A343B5427E5F4A693E12345678"
-    end_device: EndDeviceRequest = generate_class_instance(
-        EndDeviceRequest, seed=101, optional_is_none=False, lFDI=original_lfdi, deviceCategory="c0ffee"
-    )    
-    aggregator_id: int = 404
-    changed_time: datetime = generate_value(datetime, 303)
-    registration_pin: int = 505
-
-    result = EndDeviceMapper.map_from_request(end_device, aggregator_id, changed_time, registration_pin)
-    assert result is not None
-    assert isinstance(result, Site)
-    assert result.lfdi == original_lfdi
-
-
 @mock.patch("envoy.server.mapper.sep2.end_device.settings")
 def test_map_from_request(mock_settings: mock.MagicMock):
     """Simple sanity check on the mapper to ensure things don't break with a variety of values."""
@@ -197,7 +181,7 @@ def test_map_from_request(mock_settings: mock.MagicMock):
     assert result_all_set.post_rate_seconds == end_device_all_set.postRate
     assert result_all_set.changed_time == changed_time
     assert result_all_set.aggregator_id == aggregator_id
-    assert result_all_set.lfdi == end_device_all_set.lFDI.lower(), "We encode LFDI as all lower case"
+    assert result_all_set.lfdi == end_device_all_set.lFDI
     assert isinstance(result_all_set.device_category, DeviceCategory)
     assert result_all_set.device_category == int("c0ffee", 16)
     assert result_all_set.timezone_id == "abc/123"
@@ -211,7 +195,7 @@ def test_map_from_request(mock_settings: mock.MagicMock):
     assert result_optional.post_rate_seconds is None
     assert result_optional.changed_time == changed_time
     assert result_optional.aggregator_id == aggregator_id
-    assert result_optional.lfdi == end_device_optional.lFDI.lower(), "We encode LFDI as all lower case"
+    assert result_optional.lfdi == end_device_optional.lFDI
     assert isinstance(result_all_set.device_category, DeviceCategory)
     assert result_optional.device_category == DeviceCategory(0)
     assert result_optional.timezone_id == "abc/123"


### PR DESCRIPTION
Test ALL-002 failed with the error end-device-contents: "EndDevice lfdi must consist only of UPPERCASE hexadecimal characters. Got '29830e8c...'.

However, the EndDevice had been posted with all uppercase chars: <lFDI>29830E8C...

I assume that the posted EndDevice is written to database and for end-device-contents verification again loaded from db. Before writing to db it seems that the EndDeviceMapper is making the received LFDI lowercase.

Tried to fix that. Not sure though ☺️.

Feel free to reject or adjust.