### PR TITLE
Ausgrid/ed 75 client certificate checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ envoy has a full demo server for quickly evaluating its capabilities. See the [d
 
 To install envoy for local development, clone this repository and then run:
 
-`pip install -e .[dev, test]`
+`pip install -e .[dev,test]`
 
 To ensure everything is setup correctly, tests can be run with:
 
@@ -118,7 +118,7 @@ To run Envoy locally as a development environment you'll need to setup a local p
 
 1. Install dependencies for main server + tests
 
-`pip install -e .[test, dev]`
+`pip install -e .[test,dev]`
 
 2. Create an "envoy" database
 
@@ -132,7 +132,7 @@ postgres=# grant all privileges on database envoydb to envoyuser;
 Note: for postgres>=15, create privileges on the public schema are no longer created by default. 
 To enable table creation with the envoyuser, grant ownership of the database (local development only)
 ```
-postgres=# ALTER DATABASE envoydb TO OWNER envoyuser;
+postgres=# ALTER DATABASE envoydb OWNER TO envoyuser;
 ```
 
 3. Create `.env` file
@@ -153,6 +153,7 @@ We recommend adding these to a `.env` file in the root directory so that they ar
 ln -s $PWD/.env $PWD/src/envoy/server/.env
 cd src/envoy/server/
 alembic upgrade head
+cd -
 ```
 
 5. You may want to put some aggregators along with their associated lFDIs into the database created in Step 3. We can use the base config from the testing environment for this purpose:

--- a/tests/integration/response.py
+++ b/tests/integration/response.py
@@ -124,7 +124,7 @@ async def run_basic_unauthorised_tests(
     response = await client.request(
         method=method, url=uri, content=body, headers=_apply_headers(base_headers, {cert_header: "abc-123"})
     )
-    assert_response_header(response, HTTPStatus.BAD_REQUEST)
+    assert_response_header(response, HTTPStatus.INTERNAL_SERVER_ERROR)
     assert_error_response(response)
 
 

--- a/tests/unit/server/api/depends/test_lfdi_auth.py
+++ b/tests/unit/server/api/depends/test_lfdi_auth.py
@@ -7,7 +7,7 @@ from assertical.fake.generator import generate_class_instance
 from fastapi import HTTPException, Request
 from starlette.datastructures import Headers
 
-from envoy.server.api.depends.lfdi_auth import LFDIAuthDepends, is_valid_pem, is_valid_sha256
+from envoy.server.api.depends.lfdi_auth import LFDIAuthDepends, is_valid_lfdi, is_valid_pem, is_valid_sha256
 from envoy.server.crud.auth import ClientIdDetails
 from envoy.server.main import settings
 from envoy.server.model.aggregator import NULL_AGGREGATOR_ID
@@ -326,3 +326,20 @@ def test_is_valid_sha256(sha256_str, expected):
 )
 def test_cert_pem_to_cert_fingerprint(pem_bytes: bytes, sha256: str):
     assert LFDIAuthDepends._cert_pem_to_cert_fingerprint(pem_bytes.decode("utf-8")) == sha256
+
+
+@pytest.mark.parametrize(
+    "lfdi_str,expected",
+    [
+        ("996fb92427ae41e4649b934ca495991b7852b855", True),  # valid lowercase
+        ("996FB92427AE41E4649B934CA495991B7852B855", True),  # valid uppercase
+        ("996fb92427ae41e4649b934ca495991b7852b85", False),  # too short
+        ("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b8555", False),  # too long
+        ("g996fb92427ae41e4649b934ca495991b7852b855", False),  # not hex
+        ("", False),
+        (None, False),
+        (1234567890, False),  # not string
+    ],
+)
+def test_is_valid_lfdi(lfdi_str, expected):
+    assert is_valid_lfdi(lfdi_str) == expected


### PR DESCRIPTION
- Basic checks on certificate header to identify whether it's a PEM-encoded x509, SHA256 hash or LFDI. Should be enough to close #211.
- Responding with HTTP 500 on malformed certificate header value (reasoning in comments)