### PR TITLE
Changing SiteControl pow10 default to 0

### DIFF
--- a/src/envoy/server/model/config/server.py
+++ b/src/envoy/server/model/config/server.py
@@ -11,5 +11,5 @@ class RuntimeServerConfig:
     derpl_pollrate_seconds: int = 60
     derl_pollrate_seconds: int = 60
     mup_postrate_seconds: int = 60
-    site_control_pow10_encoding: int = -2
+    site_control_pow10_encoding: int = 0
     disable_edev_registration: bool = False


### PR DESCRIPTION
The SiteControl pow10 default is currently -2 (which allows sending two decimal place accuracy for Watts on DERControls). Changing it to 0.

-2 too granular and can result in pushing DERControl fields above the int16 limit. 

Two observations:
* This (and the other default values) should probably be settable via env variables (They can be overridden in the DB)
* The server should probably dynamically assign a pow10 if it's too large too but that's a seperate issue.