### PR TITLE
Fixed href missing on ConnectionPoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "taskiq!=0.11.5,!=0.11.6",      # Known compatibiity issue with pydantic
     "taskiq-aio-pika",
     "parse",
-    "envoy_schema==0.26.0",
+    "envoy_schema==0.27.0",
     "intervaltree",
 ]
 

--- a/src/envoy/server/manager/end_device.py
+++ b/src/envoy/server/manager/end_device.py
@@ -11,8 +11,8 @@ from envoy_schema.server.schema.sep2.end_device import (
     EndDeviceResponse,
     RegistrationResponse,
 )
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from envoy.notification.manager.notification import NotificationManager
 from envoy.server.crud.archive import copy_rows_into_archive
@@ -26,7 +26,7 @@ from envoy.server.crud.site import (
     select_single_site_with_sfdi,
     select_single_site_with_site_id,
 )
-from envoy.server.exception import ForbiddenError, NotFoundError, UnableToGenerateIdError, ConflictError
+from envoy.server.exception import ConflictError, ForbiddenError, NotFoundError, UnableToGenerateIdError
 from envoy.server.manager.server import RuntimeServerConfigManager
 from envoy.server.manager.time import utc_now
 from envoy.server.mapper.csip_aus.connection_point import ConnectionPointMapper
@@ -227,7 +227,7 @@ class EndDeviceManager:
         )
         if site is None:
             return None
-        return ConnectionPointMapper.map_to_response(site)
+        return ConnectionPointMapper.map_to_response(scope, site)
 
     @staticmethod
     async def update_nmi_for_site(session: AsyncSession, scope: SiteRequestScope, nmi: Optional[str]) -> bool:

--- a/src/envoy/server/mapper/csip_aus/connection_point.py
+++ b/src/envoy/server/mapper/csip_aus/connection_point.py
@@ -1,13 +1,14 @@
+from envoy_schema.server.schema import uri
 from envoy_schema.server.schema.csip_aus.connection_point import ConnectionPointResponse
 
+from envoy.server.mapper.common import generate_href
 from envoy.server.model.site import Site
+from envoy.server.request_scope import BaseRequestScope
 
 
 class ConnectionPointMapper:
     @staticmethod
-    def map_to_response(site: Site) -> ConnectionPointResponse:
-        return ConnectionPointResponse.model_validate(
-            {
-                "id": site.nmi if site.nmi else "",
-            }
+    def map_to_response(scope: BaseRequestScope, site: Site) -> ConnectionPointResponse:
+        return ConnectionPointResponse(
+            id=site.nmi if site.nmi else "", href=generate_href(uri.ConnectionPointUri, scope, site_id=site.site_id)
         )

--- a/tests/unit/server/mapper/csip_aus/test_connection_point.py
+++ b/tests/unit/server/mapper/csip_aus/test_connection_point.py
@@ -3,19 +3,27 @@ from envoy_schema.server.schema.csip_aus.connection_point import ConnectionPoint
 
 from envoy.server.mapper.csip_aus.connection_point import ConnectionPointMapper
 from envoy.server.model.site import Site
+from envoy.server.request_scope import BaseRequestScope
 
 
 def test_map_to_response():
     """Simple sanity check on the mapper to ensure things don't break with a variety of values."""
+
+    scope_all_set = generate_class_instance(BaseRequestScope, href_prefix="/my/prefix")
     site_all_set: Site = generate_class_instance(Site, seed=101, optional_is_none=False)
+
+    scope_optional = generate_class_instance(BaseRequestScope, href_prefix=None)
     site_optional: Site = generate_class_instance(Site, seed=202, optional_is_none=True)
 
-    result_all_set = ConnectionPointMapper.map_to_response(site_all_set)
+    result_all_set = ConnectionPointMapper.map_to_response(scope_all_set, site_all_set)
     assert result_all_set is not None
     assert isinstance(result_all_set, ConnectionPointResponse)
     assert result_all_set.id == site_all_set.nmi
+    assert result_all_set.href.startswith("/my/prefix")
+    assert f"/{site_all_set.site_id}/" in result_all_set.href
 
-    result_optional = ConnectionPointMapper.map_to_response(site_optional)
+    result_optional = ConnectionPointMapper.map_to_response(scope_optional, site_optional)
     assert result_optional is not None
     assert isinstance(result_optional, ConnectionPointResponse)
     assert result_optional.id == "", "None NMI maps to empty string"
+    assert f"/{site_optional.site_id}/" in result_optional.href


### PR DESCRIPTION
* ConnectionPoint wasn't encoding the href on responses - this is now fixed