### PR TITLE
Fixed subscription resources incorrectly encoding name

### DIFF
--- a/src/envoy/server/crud/subscription.py
+++ b/src/envoy/server/crud/subscription.py
@@ -135,9 +135,7 @@ async def delete_subscription_for_site(
         .select_from(Subscription)
         .where((Subscription.subscription_id == subscription_id) & (Subscription.aggregator_id == aggregator_id))
     )
-    if site_id is None:
-        fetch_count_stmt = fetch_count_stmt.where(Subscription.scoped_site_id.is_(None))
-    else:
+    if site_id is not None:
         fetch_count_stmt = fetch_count_stmt.where(Subscription.scoped_site_id == site_id)
     if (await session.execute(fetch_count_stmt)).scalar_one() != 1:
         return False

--- a/src/envoy/server/mapper/sep2/pub_sub.py
+++ b/src/envoy/server/mapper/sep2/pub_sub.py
@@ -99,20 +99,20 @@ class SubscriptionMapper:
         """Calculates the href for a Subscription.subscribedResource based on what the subscription is tracking
 
         Some combos of resource_type/scoped_site_id/resource_id may be invalid and will raise InvalidMappingError"""
+        href_site_id = sub.scoped_site_id if sub.scoped_site_id is not None else scope.display_site_id
+
         if sub.resource_type == SubscriptionResource.SITE:
             if sub.scoped_site_id is None:
                 return generate_href(EndDeviceListUri, scope)
             else:
-                return generate_href(EndDeviceUri, scope, site_id=scope.display_site_id)
+                return generate_href(EndDeviceUri, scope, site_id=href_site_id)
         elif sub.resource_type == SubscriptionResource.DYNAMIC_OPERATING_ENVELOPE:
             if sub.resource_id is None:
                 raise InvalidMappingError(
                     f"Subscribing to DOEs without a resource_id is unsupported on sub {sub.subscription_id}"
                 )
 
-            return generate_href(
-                DERControlListUri, scope, site_id=scope.display_site_id, der_program_id=sub.resource_id
-            )
+            return generate_href(DERControlListUri, scope, site_id=href_site_id, der_program_id=sub.resource_id)
         elif sub.resource_type == SubscriptionResource.READING:
             if sub.resource_id is None:
                 raise InvalidMappingError(
@@ -122,7 +122,7 @@ class SubscriptionMapper:
             return generate_href(
                 ReadingListUri,
                 scope,
-                site_id=scope.display_site_id,
+                site_id=href_site_id,
                 site_reading_type_id=sub.resource_id,
                 reading_set_id=READING_SET_ALL_ID,
             )
@@ -145,7 +145,7 @@ class SubscriptionMapper:
             return generate_href(
                 RateComponentListUri,
                 scope,
-                site_id=scope.display_site_id,
+                site_id=href_site_id,
                 tariff_id=sub.resource_id,
             )
         elif sub.resource_type == SubscriptionResource.SITE_DER_AVAILABILITY:
@@ -154,7 +154,7 @@ class SubscriptionMapper:
                     f"Subscribing to DERAvailability requires resource_id on sub {sub.subscription_id}"
                 )
 
-            return generate_href(DERAvailabilityUri, scope, site_id=scope.display_site_id, der_id=sub.resource_id)
+            return generate_href(DERAvailabilityUri, scope, site_id=href_site_id, der_id=sub.resource_id)
         elif sub.resource_type == SubscriptionResource.SITE_DER_RATING:
 
             if sub.resource_id is None:
@@ -162,7 +162,7 @@ class SubscriptionMapper:
                     f"Subscribing to DERCapability requires resource_id on sub {sub.subscription_id}"
                 )
 
-            return generate_href(DERCapabilityUri, scope, site_id=scope.display_site_id, der_id=sub.resource_id)
+            return generate_href(DERCapabilityUri, scope, site_id=href_site_id, der_id=sub.resource_id)
         elif sub.resource_type == SubscriptionResource.SITE_DER_SETTING:
 
             if sub.resource_id is None:
@@ -170,13 +170,13 @@ class SubscriptionMapper:
                     f"Subscribing to DERSettings requires resource_id on sub {sub.subscription_id}"
                 )
 
-            return generate_href(DERSettingsUri, scope, site_id=scope.display_site_id, der_id=sub.resource_id)
+            return generate_href(DERSettingsUri, scope, site_id=href_site_id, der_id=sub.resource_id)
         elif sub.resource_type == SubscriptionResource.SITE_DER_STATUS:
 
             if sub.resource_id is None:
                 raise InvalidMappingError(f"Subscribing to DERStatus requires resource_id on sub {sub.subscription_id}")
 
-            return generate_href(DERStatusUri, scope, site_id=scope.display_site_id, der_id=sub.resource_id)
+            return generate_href(DERStatusUri, scope, site_id=href_site_id, der_id=sub.resource_id)
         elif sub.resource_type == SubscriptionResource.DEFAULT_SITE_CONTROL:
 
             if sub.resource_id is None:
@@ -184,16 +184,14 @@ class SubscriptionMapper:
                     f"Subscribing to DefaultDERControl requires resource_id on sub {sub.subscription_id}"
                 )
 
-            return generate_href(
-                DefaultDERControlUri, scope, site_id=scope.display_site_id, der_program_id=sub.resource_id
-            )
+            return generate_href(DefaultDERControlUri, scope, site_id=href_site_id, der_program_id=sub.resource_id)
         elif sub.resource_type == SubscriptionResource.FUNCTION_SET_ASSIGNMENTS:
-            return generate_href(FunctionSetAssignmentsListUri, scope, site_id=scope.display_site_id)
+            return generate_href(FunctionSetAssignmentsListUri, scope, site_id=href_site_id)
         elif sub.resource_type == SubscriptionResource.SITE_CONTROL_GROUP:
             if sub.resource_id is not None:
-                return generate_href(DERProgramFSAListUri, scope, site_id=scope.display_site_id, fsa_id=sub.resource_id)
+                return generate_href(DERProgramFSAListUri, scope, site_id=href_site_id, fsa_id=sub.resource_id)
             else:
-                return generate_href(DERProgramListUri, scope, site_id=scope.display_site_id)
+                return generate_href(DERProgramListUri, scope, site_id=href_site_id)
         else:
             raise InvalidMappingError(
                 f"Cannot map a resource HREF for resource_type {sub.resource_type} on sub {sub.subscription_id}"

--- a/tests/integration/func_sets/test_pub_sub.py
+++ b/tests/integration/func_sets/test_pub_sub.py
@@ -510,7 +510,7 @@ async def test_create_subscription_site_id_mismatches_subscription(client: Async
     """When creating a sub check that the subscribed resource owns the requesting edev"""
 
     # Requests to /edev/0/* must have subbed resource be underneath /edev/0/*
-    for subbed_resource in subscribable_resource_hrefs(site_id=1, pricing_reading_type_id=1):
+    for subbed_resource in subscribable_resource_hrefs(site_id=99, pricing_reading_type_id=1):
         insert_request: Sep2Subscription = generate_class_instance(Sep2Subscription)
         insert_request.encoding = SubscriptionEncoding.XML
         insert_request.notificationURI = "https://example.com/456?foo=bar"

--- a/tests/integration/func_sets/test_pub_sub.py
+++ b/tests/integration/func_sets/test_pub_sub.py
@@ -195,18 +195,30 @@ async def test_get_subscription_list_by_page(
 
 
 @pytest.mark.parametrize(
-    "cert, site_id, sub_id, expected_404",
+    "cert, site_id, sub_id, expected_subscribed_resource",
     [
-        (AGG_1_VALID_CERT, 4, 4, False),
-        (AGG_2_VALID_CERT, 3, 3, False),
-        (AGG_3_VALID_CERT, 3, 3, True),  # Inaccessible to this aggregator
-        (AGG_1_VALID_CERT, 99, 1, True),  # invalid site id
-        (AGG_1_VALID_CERT, 1, 1, True),  # wrong site id
+        (AGG_1_VALID_CERT, 1, 99, None),  # sub DNE
+        (AGG_1_VALID_CERT, 0, 1, "/edev"),
+        (AGG_1_VALID_CERT, 2, 1, None),  # Wrong site id
+        (AGG_2_VALID_CERT, 1, 1, None),  # Wrong aggregator
+        (AGG_1_VALID_CERT, 0, 2, "/edev/2/derp/1/derc"),
+        (AGG_1_VALID_CERT, 1, 2, None),
+        (AGG_1_VALID_CERT, 2, 2, "/edev/2/derp/1/derc"),
+        (AGG_2_VALID_CERT, 1, 2, None),  # Wrong aggregator
+        (AGG_2_VALID_CERT, 0, 3, "/edev/3/tp/3/rc"),
+        (AGG_1_VALID_CERT, 0, 4, "/edev/4"),
+        (AGG_1_VALID_CERT, 4, 4, "/edev/4"),
+        (AGG_1_VALID_CERT, 0, 5, "/upt/0/mr/1/rs/all/r"),
     ],
 )
 @pytest.mark.anyio
 async def test_get_subscription_by_aggregator(
-    client: AsyncClient, sub_id: int, cert: str, site_id: int, expected_404: bool, sub_uri_format
+    client: AsyncClient,
+    sub_id: int,
+    cert: str,
+    site_id: int,
+    expected_subscribed_resource: Optional[str],
+    sub_uri_format,
 ):
     """Simple test of a valid get for different aggregator certs - validates that the response looks like XML
     and that it contains the expected subscription associated with each aggregator/site"""
@@ -216,7 +228,7 @@ async def test_get_subscription_by_aggregator(
         headers={cert_header: urllib.parse.quote(cert)},
     )
 
-    if expected_404:
+    if expected_subscribed_resource is None:
         assert_response_header(response, HTTPStatus.NOT_FOUND)
         assert_error_response(response)
     else:
@@ -224,17 +236,21 @@ async def test_get_subscription_by_aggregator(
         body = read_response_body_string(response)
         assert len(body) > 0
         parsed_response: Sep2Subscription = Sep2Subscription.from_xml(body)
+        assert parsed_response.subscribedResource == expected_subscribed_resource
         assert int(parsed_response.href[-1]) == sub_id
 
 
 @pytest.mark.parametrize(
     "cert, site_id, sub_id, expected_404",
     [
+        (AGG_1_VALID_CERT, 0, 4, False),
         (AGG_1_VALID_CERT, 4, 4, False),
+        (AGG_2_VALID_CERT, 0, 3, False),
         (AGG_2_VALID_CERT, 3, 3, False),
         (AGG_3_VALID_CERT, 3, 3, True),  # Inaccessible to this aggregator
         (AGG_1_VALID_CERT, 99, 1, True),  # invalid site id
         (AGG_1_VALID_CERT, 1, 1, True),  # wrong site id
+        (AGG_1_VALID_CERT, 0, 1, False),
     ],
 )
 @pytest.mark.anyio
@@ -276,7 +292,7 @@ async def test_create_doe_subscription(
     insert_request.notificationURI = "https://example.com/456?foo=bar"
     insert_request.subscribedResource = f"/edev/{edev_id}/derp/1/derc"
     response = await client.post(
-        sub_list_uri_format.format(site_id=edev_id),
+        sub_list_uri_format.format(site_id=0),  # All subscriptions should be made to /edev/0/sub
         headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
         content=Sep2Subscription.to_xml(insert_request),
     )
@@ -413,19 +429,17 @@ async def test_create_subscription_site_id_outside_aggregator(
 ):
     """When creating a sub check that the edev belongs to the requesting aggregator"""
 
-    # Test for both the aggregator end device AND the regular end device
-    for edev_id in [VIRTUAL_END_DEVICE_SITE_ID, 1]:
-        insert_request: Sep2Subscription = generate_class_instance(Sep2Subscription)
-        insert_request.encoding = SubscriptionEncoding.XML
-        insert_request.notificationURI = "https://example.com/456?foo=bar"
-        insert_request.subscribedResource = invalid_resource
-        response = await client.post(
-            sub_list_uri_format.format(site_id=edev_id),
-            headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
-            content=Sep2Subscription.to_xml(insert_request),
-        )
-        assert_response_header(response, HTTPStatus.BAD_REQUEST)
-        assert_error_response(response)
+    insert_request: Sep2Subscription = generate_class_instance(Sep2Subscription)
+    insert_request.encoding = SubscriptionEncoding.XML
+    insert_request.notificationURI = "https://example.com/456?foo=bar"
+    insert_request.subscribedResource = invalid_resource
+    response = await client.post(
+        sub_list_uri_format.format(site_id=VIRTUAL_END_DEVICE_SITE_ID),
+        headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
+        content=Sep2Subscription.to_xml(insert_request),
+    )
+    assert_response_header(response, HTTPStatus.BAD_REQUEST)
+    assert_error_response(response)
 
 
 @pytest.mark.parametrize("sub_href", subscribable_resource_hrefs(site_id=1, pricing_reading_type_id=1))
@@ -435,14 +449,13 @@ async def test_create_site_scoped_subscription_entry_added_to_db(
 ):
     """Simple test that subscription creation works across endpoints from subscribable_resource_hrefs
     (when the subscription is going to be scoped to a single site)"""
-    edev_id = 1
 
     insert_request: Sep2Subscription = generate_class_instance(Sep2Subscription)
     insert_request.encoding = SubscriptionEncoding.XML
     insert_request.notificationURI = "https://example.com/456?foo=bar"
     insert_request.subscribedResource = sub_href
     response = await client.post(
-        sub_list_uri_format.format(site_id=edev_id),
+        sub_list_uri_format.format(site_id=VIRTUAL_END_DEVICE_SITE_ID),
         headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
         content=Sep2Subscription.to_xml(insert_request),
     )
@@ -455,7 +468,7 @@ async def test_create_site_scoped_subscription_entry_added_to_db(
     async with generate_async_session(pg_base_config) as session:
         resp = await session.execute(select(Subscription).where(Subscription.subscription_id == sub_id).limit(1))
         created_sub = resp.scalars().first()
-        assert created_sub.scoped_site_id == edev_id, "Expected a site scoped sub"
+        assert created_sub.scoped_site_id == 1, "Expected a site scoped sub"
         assert_nowish(created_sub.changed_time)
 
 

--- a/tests/unit/server/crud/test_subscription.py
+++ b/tests/unit/server/crud/test_subscription.py
@@ -552,15 +552,18 @@ async def test_upsert_subscription_update_subscription(pg_base_config, sub: Subs
     "agg_id, site_id, sub_id, expected_deletion, condition_count",
     [
         (1, None, 1, True, 0),
-        (1, None, 5, True, 2),
+        (1, 1, 1, False, 0),  # Sub 1 is site unscoped and can't be deleted by EndDevice 1
+        (1, None, 2, True, 0),
         (1, 2, 2, True, 0),
+        (2, None, 3, True, 0),
         (2, 3, 3, True, 0),
+        (1, None, 4, True, 0),
+        (1, 4, 4, True, 0),
+        (1, None, 5, True, 2),
+        (1, 1, 5, False, 2),  # Sub 5 is site unscoped and can't be deleted by EndDevice 1
         (2, None, 1, False, 0),  # Bad Aggregator ID
         (99, None, 1, False, 0),  # Bad Aggregator ID
-        (2, 2, 2, False, 0),  # Bad Aggregator ID
-        (99, 2, 2, False, 0),  # Bad Aggregator ID
-        (1, 1, 1, False, 0),  # Site ID is wrong
-        (1, None, 2, False, 0),  # Site ID missing
+        (1, 2, 1, False, 0),  # Site ID is wrong
         (1, None, 99, False, 0),  # Sub ID is wrong
         (1, 1, 5, False, 2),  # Site ID is wrong (but also has child conditions)
         (2, None, 5, False, 2),  # Agg ID is wrong (but also has child conditions)

--- a/tests/unit/server/mapper/sep2/test_pub_sub.py
+++ b/tests/unit/server/mapper/sep2/test_pub_sub.py
@@ -113,7 +113,7 @@ def test_SubscriptionMapper_calculate_resource_href_at_least_one_supported_combo
     scope: DeviceOrAggregatorRequestScope = generate_class_instance(
         DeviceOrAggregatorRequestScope, display_site_id=display_site_id, href_prefix="/foo/bar"
     )
-    for site_id, resource_id in product([1, None], [2, None]):
+    for site_id, resource_id in product([1129414, None], [82521517, None]):
         sub: Subscription = generate_class_instance(Subscription)
         sub.resource_type = resource
         sub.scoped_site_id = site_id
@@ -124,7 +124,10 @@ def test_SubscriptionMapper_calculate_resource_href_at_least_one_supported_combo
             assert href and isinstance(href, str)
             assert href.startswith(scope.href_prefix)
             if resource != SubscriptionResource.SITE:
-                assert f"/{display_site_id}" in href, "Validating the display_site_id is being used over site_id"
+                if sub.scoped_site_id is None:
+                    assert f"/{display_site_id}" in href, "display_site_id is being used if site_id not specified"
+                else:
+                    assert f"/{site_id}" in href
 
             hrefs.append(href)
         except InvalidMappingError:
@@ -174,7 +177,7 @@ def test_SubscriptionMapper_calculate_resource_href_encodes_site_id(
 
     sub: Subscription = generate_class_instance(Subscription)
     sub.resource_type = resource
-    sub.scoped_site_id = 8912491  # We want to ignore this value and use the display_site_id from the scope
+    sub.scoped_site_id = 8912491  # This should be used
     sub.resource_id = None
 
     try:
@@ -183,7 +186,7 @@ def test_SubscriptionMapper_calculate_resource_href_encodes_site_id(
         sub.resource_id = 888
         href = SubscriptionMapper.calculate_resource_href(sub, scope)
 
-    assert f"/{scope.display_site_id}" in href, "Expected display site id in href"
+    assert f"/{sub.scoped_site_id}" in href
 
 
 @pytest.mark.parametrize("resource, site_id, resource_id", product(SubscriptionResource, [1, None], [2, None]))


### PR DESCRIPTION
* Subscriptions through the aggregator EndDevice had a number of errors on creation/fetching when the subscribed EndDevice ID was not /edev/0