### PR TITLE
updates to pg12 image to support deterministic attributre

### DIFF
--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
         condition: service_healthy
 
   envoy-db:
-    image: timescale/timescaledb:latest-pg10
+    image: timescale/timescaledb:latest-pg12
     ports:
       - 127.0.0.1:8003:5432
     volumes:


### PR DESCRIPTION
When trying to spin up the demo, I was running into issues on db initialization. This was caused because the `envoy-db` service is using a postgres 10 image which does not support the `deterministic` attribute used in one of the migration files. 
This PR just updates the docker-compose file to use image `timescale/timescaledb:latest-pg12`