### PR TITLE
feat: updated demo docker compose to use postgres:16

### DIFF
--- a/demo/db-init/Dockerfile
+++ b/demo/db-init/Dockerfile
@@ -2,6 +2,8 @@ FROM envoy:latest
 
 WORKDIR /app/src/envoy/server/
 
+ENV AGG_CERT_PATH="/test_certs/testaggregator.crt"
+
 COPY --chmod=700 ./entrypoint.sh /entrypoint.sh
 COPY  ./init_db.py ./init_db.py
 

--- a/demo/db-init/init_db.py
+++ b/demo/db-init/init_db.py
@@ -18,7 +18,7 @@ from envoy.server.model.doe import SiteControlGroup
 # Aggregators have their certificates recorded in public.certificate
 # while devices do not - envoy does not keep a record of non-aggregator
 # device certificates.
-AGG_CERT_PATH = "/test_certs/testaggregator.crt"  # Aggregator Client
+AGG_CERT_PATH = os.environ.get("AGG_CERT_PATH", "/test_certs/testaggregator.crt")  # Aggregator Client
 
 
 def load_cert(cert_path: str, now: datetime) -> Certificate:

--- a/demo/docker-compose.yaml
+++ b/demo/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
         condition: service_healthy
 
   envoy-db:
-    image: timescale/timescaledb:latest-pg10
+    image: postgres:16
     ports:
       - 127.0.0.1:8003:5432
     volumes:
@@ -142,5 +142,5 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: ./tls-termination/test_certs/
+      device: "${PWD}/tls-termination/test_certs/"
       o: bind


### PR DESCRIPTION
Like cactus-runner dev compose file. Had become incompatible with timescale version.  
On our storage extension branch we will be using the db-init to create its own image on new tag and release, to be used for our various testing purposes. Turned the ARG_CERT_PATH variable to an env var. 

WSL2 + Docker Desktop doesn't like relative file locations in docker-compose files so utilising the PWD env variable instead.

Relates to AB#205964
