### PR TITLE
Fixed EndDeviceList pollRate Notifications

### DIFF
--- a/src/envoy/admin/crud/aggregator.py
+++ b/src/envoy/admin/crud/aggregator.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Iterable
+from typing import Iterable, Sequence
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,7 +14,7 @@ async def count_all_aggregators(session: AsyncSession) -> int:
     return resp.scalar_one()
 
 
-async def select_all_aggregators(session: AsyncSession, start: int, limit: int) -> Sequence[Aggregator]:
+async def select_all_aggregators(session: AsyncSession, start: int | None, limit: int | None) -> Sequence[Aggregator]:
     """Admin selecting of aggregators - will include domains relationship (the NULL_AGGREGATOR is not included)"""
 
     stmt = (

--- a/src/envoy/admin/manager/config.py
+++ b/src/envoy/admin/manager/config.py
@@ -35,13 +35,18 @@ class ConfigManager:
         else:
             existing_db_config.changed_time = now
 
+        changed_fsal_pollrate = False
+        changed_edevl_pollrate = False
+
         if updated_values.dcap_pollrate_seconds is not None:
             existing_db_config.dcap_pollrate_seconds = updated_values.dcap_pollrate_seconds
 
         if updated_values.edevl_pollrate_seconds is not None:
+            changed_edevl_pollrate = existing_db_config.edevl_pollrate_seconds != updated_values.edevl_pollrate_seconds
             existing_db_config.edevl_pollrate_seconds = updated_values.edevl_pollrate_seconds
 
         if updated_values.fsal_pollrate_seconds is not None:
+            changed_fsal_pollrate = existing_db_config.fsal_pollrate_seconds != updated_values.fsal_pollrate_seconds
             existing_db_config.fsal_pollrate_seconds = updated_values.fsal_pollrate_seconds
 
         if updated_values.derpl_pollrate_seconds is not None:
@@ -61,7 +66,13 @@ class ConfigManager:
 
         await session.commit()
 
-        await NotificationManager.notify_changed_deleted_entities(SubscriptionResource.FUNCTION_SET_ASSIGNMENTS, now)
+        if changed_fsal_pollrate:
+            await NotificationManager.notify_changed_deleted_entities(
+                SubscriptionResource.FUNCTION_SET_ASSIGNMENTS, now
+            )
+
+        if changed_edevl_pollrate:
+            await NotificationManager.notify_changed_deleted_entities(SubscriptionResource.SITE, now)
 
     @staticmethod
     async def fetch_config_response(session: AsyncSession) -> RuntimeServerConfigResponse:

--- a/src/envoy/server/mapper/sep2/pub_sub.py
+++ b/src/envoy/server/mapper/sep2/pub_sub.py
@@ -453,6 +453,7 @@ class NotificationMapper:
         scope: AggregatorRequestScope,
         notification_type: NotificationType,
         disable_registration: bool,
+        poll_rate_seconds: int,
     ) -> Notification:
         """Turns a list of sites into a notification"""
         return Notification.model_validate(
@@ -462,6 +463,7 @@ class NotificationMapper:
                 "status": _map_to_notification_status(notification_type),
                 "resource": {
                     "type": XSI_TYPE_END_DEVICE_LIST,
+                    "pollRate": poll_rate_seconds,
                     "all_": len(sites),
                     "results": len(sites),
                     "EndDevice": [EndDeviceMapper.map_to_response(scope, s, disable_registration, 0) for s in sites],

--- a/tests/unit/admin/crud/test_aggregator.py
+++ b/tests/unit/admin/crud/test_aggregator.py
@@ -2,13 +2,13 @@ import datetime as dt
 
 import psycopg
 import pytest
-from assertical.fixtures.postgres import generate_async_session
 import sqlalchemy as sa
+from assertical.fixtures.postgres import generate_async_session
 from sqlalchemy.exc import IntegrityError
 
+from envoy.admin import crud
 from envoy.admin.crud.certificate import select_all_certificates_for_aggregator
 from envoy.server import model
-from envoy.admin import crud
 from envoy.server.crud.aggregator import select_aggregator
 
 
@@ -27,8 +27,10 @@ async def test_count_all_aggregators_empty(pg_empty_config: psycopg.Connection) 
 @pytest.mark.parametrize(
     "start, limit, expected_aggregator_ids, expected_domain_ids",
     [
+        (None, None, [1, 2, 3], [1, 2, 3, 4]),
         (0, 500, [1, 2, 3], [1, 2, 3, 4]),
         (0, 1, [1], [1, 4]),
+        (None, 1, [1], [1, 4]),
         (1, 1, [2], [2]),
         (2, 1, [3], [3]),
         (3, 1, [], []),

--- a/tests/unit/server/mapper/sep2/test_pub_sub.py
+++ b/tests/unit/server/mapper/sep2/test_pub_sub.py
@@ -532,7 +532,7 @@ def test_NotificationMapper_map_sites_to_response(notification_type: Notificatio
         DeviceOrAggregatorRequestScope, seed=1001, href_prefix="/custom/prefix"
     )
 
-    notification = NotificationMapper.map_sites_to_response([site1, site2], sub, scope, notification_type, False)
+    notification = NotificationMapper.map_sites_to_response([site1, site2], sub, scope, notification_type, False, 9876)
     assert isinstance(notification, Notification)
     assert notification.subscribedResource.startswith("/custom/prefix")
     assert EndDeviceListUri in notification.subscribedResource
@@ -544,6 +544,7 @@ def test_NotificationMapper_map_sites_to_response(notification_type: Notificatio
         assert notification.status == NotificationStatus.DEFAULT
 
     assert notification.resource.type == XSI_TYPE_END_DEVICE_LIST
+    assert notification.resource.pollRate == 9876
     assert_list_type(EndDeviceResponse, notification.resource.EndDevice, count=2)
     assert_entity_hrefs_contain_entity_id_and_prefix(
         [e.href for e in notification.resource.EndDevice], [site1.site_id, site2.site_id], scope.href_prefix


### PR DESCRIPTION
* EndDeviceList wasn't generating pub/sub Notifications when pollRate changed
* FSAList was generating pub/sub Notifications even if the pollRate was unchanged