### PR TITLE
fix: guard against UnboundLocalError on null doeModesEnabled

### DIFF
--- a/src/envoy/server/mapper/sep2/der.py
+++ b/src/envoy/server/mapper/sep2/der.py
@@ -509,6 +509,8 @@ class DERSettingMapper:
     @staticmethod
     def map_from_request(changed_time: datetime, der_setting: DERSettings) -> SiteDERSetting:
         modes_enabled: Optional[DERControlType] = None
+        doe_modes_enabled: Optional[DERControlType] = None
+
         if der_setting.modesEnabled:
             modes_enabled = DERControlType(int(der_setting.modesEnabled, 16))
         if der_setting.doeModesEnabled:

--- a/tests/unit/server/mapper/sep2/test_der.py
+++ b/tests/unit/server/mapper/sep2/test_der.py
@@ -215,8 +215,10 @@ def test_der_settings_roundtrip(optional_is_none: bool):
     expected: DERSettings = generate_class_instance(
         DERSettings, seed=101, optional_is_none=optional_is_none, generate_relationships=True
     )
-    expected.modesEnabled = to_hex_binary(DERControlType.OP_MOD_HFRT_MAY_TRIP | DERControlType.OP_MOD_FREQ_DROOP)
-    expected.doeModesEnabled = to_hex_binary(DOESupportedMode.OP_MOD_EXPORT_LIMIT_W)
+    if not optional_is_none:
+        expected.modesEnabled = to_hex_binary(DERControlType.OP_MOD_HFRT_MAY_TRIP | DERControlType.OP_MOD_FREQ_DROOP)
+        expected.doeModesEnabled = to_hex_binary(DOESupportedMode.OP_MOD_EXPORT_LIMIT_W)
+
     scope: DeviceOrAggregatorRequestScope = generate_class_instance(
         DeviceOrAggregatorRequestScope, seed=9876, href_prefix="/my/prefix"
     )


### PR DESCRIPTION
Found this erroring when testing an aggregator with no doeModesEnabled supplied, as is allowed by the schema and the model.