### PR TITLE
fix(enddevice): lfdi provisioning between aggregators and direct devices

### DIFF
--- a/tests/unit/server/manager/test_end_device.py
+++ b/tests/unit/server/manager/test_end_device.py
@@ -18,7 +18,13 @@ from envoy_schema.server.schema.sep2.end_device import (
 )
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from envoy.server.exception import ConflictError, ForbiddenError, NotFoundError, UnableToGenerateIdError, BadRequestError
+from envoy.server.exception import (
+    ConflictError,
+    ForbiddenError,
+    NotFoundError,
+    UnableToGenerateIdError,
+    BadRequestError,
+)
 from envoy.server.manager.end_device import (
     MAX_REGISTRATION_PIN,
     EndDeviceManager,

--- a/tests/unit/server/manager/test_end_device.py
+++ b/tests/unit/server/manager/test_end_device.py
@@ -23,7 +23,6 @@ from envoy.server.exception import (
     ForbiddenError,
     NotFoundError,
     UnableToGenerateIdError,
-    BadRequestError,
 )
 from envoy.server.manager.end_device import (
     MAX_REGISTRATION_PIN,


### PR DESCRIPTION
This fixes a bug observed surrounding direct device clients being rejected (403) for not supplying an LFDI in their request payloads and is instead inferred from the cert header. LFDIs are optional according to the 2030.5 xsd, which is the applicability of direct devices. 

In this solution however a 400 is now being issued to an aggregator client in the event they don't supply an lfdi for an end device. I believe this allows for the requirements in particular for TS5573 section 4.2.

Checks and tests that involve  regenerating missing SFDIs have largely been removed, since the SFDI field is mandatory for an end device payload, hence should be handled by pydantic and result in a 400.