### PR TITLE
Pow10multipliier validation

### DIFF
--- a/demo/reset.sh
+++ b/demo/reset.sh
@@ -7,7 +7,7 @@ docker build --pull --no-cache -t envoy:latest -f ../Dockerfile.server ../
 
 HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose down -v
 
-HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d --build
 
 echo ""
 echo "Stack is up. Smoke test with:"

--- a/demo/reset.sh
+++ b/demo/reset.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+cd "$(dirname "$0")"
+
+docker build --pull --no-cache -t envoy:latest -f ../Dockerfile.server ../
+
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose down -v
+
+HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose up -d
+
+echo ""
+echo "Stack is up. Smoke test with:"
+echo "  curl --cacert ./tls-termination/test_certs/testca.crt --cert ./tls-termination/test_certs/testdevice1.p12: --cert-type p12 https://localhost:8443/dcap"

--- a/src/envoy/server/mapper/common.py
+++ b/src/envoy/server/mapper/common.py
@@ -137,5 +137,5 @@ class CaseInsensitiveDict(abc.MutableMapping, Generic[ValueType]):
 # IEEE 2030.5 integer type bounds used for inbound payload validation
 SEP2_INT8_MIN = -128
 SEP2_INT8_MAX = 127
-SEP2_INT48_MIN = -(2**47)    # -140_737_488_355_328
+SEP2_INT48_MIN = -(2**47)  # -140_737_488_355_328
 SEP2_INT48_MAX = (2**47) - 1  # 140_737_488_355_327

--- a/src/envoy/server/mapper/common.py
+++ b/src/envoy/server/mapper/common.py
@@ -132,3 +132,10 @@ class CaseInsensitiveDict(abc.MutableMapping, Generic[ValueType]):
 
     def __repr__(self) -> str:
         return "%s(%r)" % (self.__class__.__name__, dict(self.items()))
+
+
+# IEEE 2030.5 integer type bounds used for inbound payload validation
+SEP2_INT8_MIN = -128
+SEP2_INT8_MAX = 127
+SEP2_INT48_MIN = -(2**47)    # -140_737_488_355_328
+SEP2_INT48_MAX = (2**47) - 1  # 140_737_488_355_327

--- a/src/envoy/server/mapper/sep2/metering.py
+++ b/src/envoy/server/mapper/sep2/metering.py
@@ -21,7 +21,14 @@ from envoy_schema.server.schema.sep2.types import (
 
 from envoy.server.crud.site_reading import GroupedSiteReadingTypeDetails
 from envoy.server.exception import InvalidMappingError
-from envoy.server.mapper.common import CaseInsensitiveDict, generate_href
+from envoy.server.mapper.common import (
+    CaseInsensitiveDict,
+    SEP2_INT8_MAX,
+    SEP2_INT8_MIN,
+    SEP2_INT48_MAX,
+    SEP2_INT48_MIN,
+    generate_href,
+)
 from envoy.server.mapper.sep2.der import to_hex_binary
 from envoy.server.model.site_reading import SiteReading, SiteReadingType
 from envoy.server.request_scope import BaseRequestScope
@@ -153,6 +160,11 @@ class MirrorUsagePointMapper:
             power_of_ten_multiplier = 0
         else:
             power_of_ten_multiplier = rt.powerOfTenMultiplier
+        if not (SEP2_INT8_MIN <= power_of_ten_multiplier <= SEP2_INT8_MAX):
+            raise InvalidMappingError(
+                f"ReadingType.powerOfTenMultiplier {power_of_ten_multiplier} is outside the int8 range "
+                f"[{SEP2_INT8_MIN}, {SEP2_INT8_MAX}]"
+            )
         if rt.dataQualifier is None:
             data_qualifier = DataQualifierType.NOT_APPLICABLE
         else:
@@ -278,6 +290,11 @@ class MirrorMeterReadingMapper:
 
         if reading.timePeriod is None:
             raise InvalidMappingError("Reading.timePeriod was not specified")
+
+        if reading.value is not None and not (SEP2_INT48_MIN <= reading.value <= SEP2_INT48_MAX):
+            raise InvalidMappingError(
+                f"Reading.value {reading.value} is outside the int48 range [{SEP2_INT48_MIN}, {SEP2_INT48_MAX}]"
+            )
 
         if reading.localID is None:
             local_id = None

--- a/tests/integration/func_sets/test_metering_mirror.py
+++ b/tests/integration/func_sets/test_metering_mirror.py
@@ -409,7 +409,7 @@ async def test_create_update_mup_href_prefix(
     "min_val, max_val",
     [
         (9, -10),  # Normal values
-        (int("FFFFFFFFFFFF", 16), -int("FFFFFFFFFFFF", 16)),  # int48 max/min values (sep2 uses int48 value range)
+        ((2**47) - 1, -(2**47)),  # int48 max/min values (sep2 uses int48 value range)
         (0, 0),  # zero values
     ],
 )
@@ -471,7 +471,7 @@ async def test_submit_mirror_meter_reading(client: AsyncClient, pg_base_config, 
     "min_val, max_val",
     [
         (9, -10),  # Normal values
-        (int("FFFFFFFFFFFF", 16), -int("FFFFFFFFFFFF", 16)),  # int48 max/min values (sep2 uses int48 value range)
+        ((2**47) - 1, -(2**47)),  # int48 max/min values (sep2 uses int48 value range)
         (0, 0),  # zero values
     ],
 )

--- a/tests/unit/server/manager/test_metering.py
+++ b/tests/unit/server/manager/test_metering.py
@@ -100,7 +100,7 @@ async def test_create_or_update_mirror_usage_point_missing_reading_type(pg_base_
     mmr1 = generate_class_instance(
         MirrorMeterReading,
         mRID="111abc",
-        readingType=generate_class_instance(ReadingType, seed=404),
+        readingType=generate_class_instance(ReadingType, seed=404, powerOfTenMultiplier=3),
         reading=None,
     )
 
@@ -191,13 +191,13 @@ async def test_create_or_update_mirror_usage_point_created_no_readings(pg_base_c
     mmr1 = generate_class_instance(
         MirrorMeterReading,
         mRID="111abc",
-        readingType=generate_class_instance(ReadingType, seed=404),
+        readingType=generate_class_instance(ReadingType, seed=404, powerOfTenMultiplier=3),
     )
 
     mmr2 = generate_class_instance(
         MirrorMeterReading,
         mRID="222abc",
-        readingType=generate_class_instance(ReadingType, seed=505),
+        readingType=generate_class_instance(ReadingType, seed=505, powerOfTenMultiplier=3),
     )
 
     mup = generate_class_instance(
@@ -283,14 +283,14 @@ async def test_create_or_update_mirror_usage_point_created_with_readings(pg_base
     mmr1 = generate_class_instance(
         MirrorMeterReading,
         mRID="111abc",
-        readingType=generate_class_instance(ReadingType, seed=404),
+        readingType=generate_class_instance(ReadingType, seed=404, powerOfTenMultiplier=3),
         reading=reading1,
     )
 
     mmr2 = generate_class_instance(
         MirrorMeterReading,
         mRID="222abc",
-        readingType=generate_class_instance(ReadingType, seed=505),
+        readingType=generate_class_instance(ReadingType, seed=505, powerOfTenMultiplier=3),
         mirrorReadingSets=[generate_class_instance(MirrorReadingSet, readings=[reading2, reading3])],
     )
 
@@ -422,7 +422,7 @@ async def test_create_or_update_mirror_usage_point_update(
     mmr_new = generate_class_instance(
         MirrorMeterReading,
         mRID=force_case(force_upper_case, "abc123DEF"),
-        readingType=generate_class_instance(ReadingType, seed=404),
+        readingType=generate_class_instance(ReadingType, seed=404, powerOfTenMultiplier=3),
         reading=reading2,
     )
 
@@ -430,7 +430,7 @@ async def test_create_or_update_mirror_usage_point_update(
     mmr5 = generate_class_instance(
         MirrorMeterReading,
         mRID=force_case(force_upper_case, "50000000000000000000000000000Abc"),
-        readingType=generate_class_instance(ReadingType, seed=505),
+        readingType=generate_class_instance(ReadingType, seed=505, powerOfTenMultiplier=3),
         reading=reading3,
     )
 

--- a/tests/unit/server/mapper/sep2/test_metering.py
+++ b/tests/unit/server/mapper/sep2/test_metering.py
@@ -27,7 +27,13 @@ from envoy_schema.server.schema.sep2.types import (
 
 from envoy.server.crud.site_reading import GroupedSiteReadingTypeDetails
 from envoy.server.exception import InvalidMappingError
-from envoy.server.mapper.common import CaseInsensitiveDict
+from envoy.server.mapper.common import (
+    CaseInsensitiveDict,
+    SEP2_INT8_MAX,
+    SEP2_INT8_MIN,
+    SEP2_INT48_MAX,
+    SEP2_INT48_MIN,
+)
 from envoy.server.mapper.sep2.der import to_hex_binary
 from envoy.server.mapper.sep2.metering import (
     MirrorMeterReadingMapper,
@@ -263,7 +269,7 @@ def test_MirrorUsagePointMapper_map_from_request():
     role_flags = RoleFlagsType.IS_PEV
     mmr_all_set = generate_class_instance(MirrorMeterReading, seed=202)
     mmr_all_set.readingType = generate_class_instance(
-        ReadingType, seed=303, optional_is_none=False, uom=UomType.APPARENT_POWER_VA
+        ReadingType, seed=303, optional_is_none=False, uom=UomType.APPARENT_POWER_VA, powerOfTenMultiplier=3
     )
 
     mmr_optional = generate_class_instance(MirrorMeterReading, seed=505)
@@ -633,3 +639,81 @@ def test_MirrorMeterReadingMapper_reading_round_trip():
         reading_roundtrip,
         ignored_properties=set(["href", "type", "touTier", "subscribable", "consumptionBlock"]),
     )
+
+
+def _make_reading(value: Optional[int]) -> Reading:
+    reading: Reading = generate_class_instance(Reading, optional_is_none=True)
+    reading.timePeriod = generate_class_instance(DateTimeIntervalType)
+    reading.timePeriod.start = int(datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp())
+    reading.timePeriod.duration = 300
+    reading.qualityFlags = f"{QualityFlagsType.NONE:0X}"
+    reading.value = value
+    return reading
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        SEP2_INT48_MAX + 1,
+        SEP2_INT48_MIN - 1,
+        3_000_000_000_000_000,   # value from S-ALL-47 step 3B
+        -3_000_000_000_000_000,
+    ],
+)
+def test_MirrorMeterReadingMapper_map_reading_from_request_value_overflow(bad_value: int):
+    """Reading.value outside int48 range must be rejected"""
+    with pytest.raises(InvalidMappingError):
+        MirrorMeterReadingMapper.map_reading_from_request(_make_reading(bad_value), 1, datetime.now())
+
+
+@pytest.mark.parametrize(
+    "ok_value",
+    [SEP2_INT48_MAX, SEP2_INT48_MIN, 100_000, 0, None],
+)
+def test_MirrorMeterReadingMapper_map_reading_from_request_value_in_range(ok_value: Optional[int]):
+    """Reading.value within int48 range (and None) must be accepted"""
+    result = MirrorMeterReadingMapper.map_reading_from_request(_make_reading(ok_value), 1, datetime.now())
+    assert result.value == ok_value
+
+
+def _make_mmr_with_multiplier(multiplier: Optional[int]) -> MirrorMeterReading:
+    mmr = generate_class_instance(MirrorMeterReading, mRID="abc123")
+    mmr.readingType = generate_class_instance(ReadingType, uom=UomType.REAL_POWER_WATT, optional_is_none=False)
+    mmr.readingType.powerOfTenMultiplier = multiplier
+    return mmr
+
+
+def _map_mup(mmr: MirrorMeterReading) -> SiteReadingType:
+    return MirrorUsagePointMapper.map_from_request(
+        mmr,
+        aggregator_id=1,
+        site_id=2,
+        group_id=3,
+        group_mrid="grp1",
+        group_description=None,
+        group_version=None,
+        group_status=None,
+        role_flags=RoleFlagsType.NONE,
+        changed_time=datetime.now(),
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_mult",
+    [SEP2_INT8_MAX + 1, SEP2_INT8_MIN - 1, 1000, -1000],
+)
+def test_MirrorUsagePointMapper_map_from_request_bad_multiplier(bad_mult: int):
+    """powerOfTenMultiplier outside int8 range must be rejected"""
+    with pytest.raises(InvalidMappingError):
+        _map_mup(_make_mmr_with_multiplier(bad_mult))
+
+
+@pytest.mark.parametrize(
+    "ok_mult",
+    [SEP2_INT8_MAX, SEP2_INT8_MIN, 0, 1, None],
+)
+def test_MirrorUsagePointMapper_map_from_request_ok_multiplier(ok_mult: Optional[int]):
+    """powerOfTenMultiplier within int8 range (and None) must be accepted"""
+    result = _map_mup(_make_mmr_with_multiplier(ok_mult))
+    expected = ok_mult if ok_mult is not None else 0
+    assert result.power_of_ten_multiplier == expected

--- a/tests/unit/server/mapper/sep2/test_metering.py
+++ b/tests/unit/server/mapper/sep2/test_metering.py
@@ -656,7 +656,7 @@ def _make_reading(value: Optional[int]) -> Reading:
     [
         SEP2_INT48_MAX + 1,
         SEP2_INT48_MIN - 1,
-        3_000_000_000_000_000,   # value from S-ALL-47 step 3B
+        3_000_000_000_000_000,  # value from S-ALL-47 step 3B
         -3_000_000_000_000_000,
     ],
 )


### PR DESCRIPTION
Two features:
1) Add a .sh script to rebuild the demo server to make changes easier to update/test against cactus-client
2) Add pow10multipier/value validation to MUPs and readings in order to pass S-ALL-47. 

It is possible we should consider something a bit more generalisable for these ranges of ints being validated elsewhere beyond this bandaid fix?