### PR TITLE
Blacklisting taskiq-aio-pika v0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "cryptography",
     "httpx",
     "taskiq!=0.11.5,!=0.11.6",      # Known compatibiity issue with pydantic
-    "taskiq-aio-pika",
+    "taskiq-aio-pika!=0.6.0",
     "parse",
     "intervaltree",
 ]


### PR DESCRIPTION
taskiq-aio-pika v0.6.0 introduces a compatibility issue with RabbitMQ / TaskIQ such that enqueing a message with a delay fails. Earlier versions work OK - we will need to retest future releases as they develop