### PR TITLE
mtls support for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Typically settings are set by setting an environment variable with the same name
 | `iana_pen` | `int` | Defaults to 0. The Internet Assigned Numbers Authority - Private Enterprise Number of the organisation hosting this instance. This value will be used in all encoded MRIDs as per sep2 specifications. |
 | `sqlalchemy_engine_arguments` | `str` | A JSON encoded dictionary of additional parameters to pass to the SQL Alchemy `create_engine` function. Please see the [SQL Alchemy](https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine) docs for specifics.  Example: `{"pool_size":10, "max_overflow":15}`. Please note that `pool_recycle` will be overridden if `azure_ad_db_refresh_secs` is set |
 | `notification_disable_tls_verify` | `bool` | If `true`, disables TLS certificate verification for outbound notification requests to subscription recipients. Defaults to `false`. |
+| `notifications_with_mtls` | `bool` | If `true`, present a client certificate (mTLS) on outbound notification requests. Requires `notification_mtls_cert` and `notification_mtls_key` to be set. Defaults to `false`. |
+| `notification_mtls_cert` | `string` | Path to the client certificate PEM file presented on outbound notifications when `notifications_with_mtls` is enabled. |
+| `notification_mtls_key` | `string` | Path to the client private key PEM file for `notification_mtls_cert` when `notifications_with_mtls` is enabled. |
+| `notification_mtls_serca` | `string` | Optional path to a SERCA PEM file used to verify the subscription recipient's server certificate. If unset, the system CA store is used. |
 
 **Additional Utility Server Settings (server)**
 

--- a/src/envoy/notification/handler.py
+++ b/src/envoy/notification/handler.py
@@ -1,6 +1,8 @@
 import logging
+import ssl
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
 from contextlib import _AsyncGeneratorContextManager, asynccontextmanager
+from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import FastAPI
@@ -15,8 +17,42 @@ logger = logging.getLogger(__name__)
 STATE_DB_SESSION_MAKER = "db_session_maker"
 # TaskIQ state key for an optional string
 STATE_HREF_PREFIX = "href_prefix"
-# TaskIQ state key for disabling TLS verification on outbound notification requests
-STATE_DISABLE_TLS_VERIFY = "disable_tls_verify"
+# TaskIQ state key for the prebuilt httpx "verify" argument used on outbound notification requests. This is either a
+# bool (standard TLS verification toggle) or a reusable SSLContext holding the mTLS client certificate (built once at
+# WORKER_STARTUP so the certificate files are only read from disk on worker startup)
+STATE_TLS_VERIFY = "tls_verify"
+
+
+@dataclass(frozen=True)
+class MtlsConfig:
+    """Client certificate configuration for mTLS on outbound notification requests"""
+
+    cert_path: str  # Path to client certificate PEM file
+    key_path: str  # Path to client private key PEM file
+    serca_path: str | None  # Path to SERCA PEM for verifying device server certs (None = system CAs)
+
+
+def build_tls_verify(disable_tls_verify: bool, mtls_config: MtlsConfig | None) -> ssl.SSLContext | bool:
+    """Builds the httpx "verify" argument for outbound notifications. With mTLS configured this reads the client
+    certificate (and optional SERCA) from disk into a reusable SSLContext; otherwise returns a bool toggling standard
+    TLS verification. Intended to be called once at worker startup so the certificate files are not re-read per request.
+    """
+    if mtls_config is None:
+        return not disable_tls_verify
+
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
+    ssl_context.set_ciphers("ECDHE-ECDSA-AES128-CCM8:ALL:!aNULL")
+    if disable_tls_verify:
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+    else:
+        ssl_context.check_hostname = True
+        ssl_context.verify_mode = ssl.CERT_REQUIRED
+        if mtls_config.serca_path is not None:
+            ssl_context.load_verify_locations(cafile=mtls_config.serca_path)
+    ssl_context.load_cert_chain(certfile=mtls_config.cert_path, keyfile=mtls_config.key_path)
+    return ssl_context
 
 
 # Reference to the shared InMemoryBroker. Will be lazily instantiated
@@ -98,8 +134,8 @@ async def href_prefix_dependency(context: Annotated[Context, TaskiqDepends()]) -
     return getattr(context.state, STATE_HREF_PREFIX, None)
 
 
-async def disable_tls_verify_dependency(context: Annotated[Context, TaskiqDepends()]) -> bool:
-    return getattr(context.state, STATE_DISABLE_TLS_VERIFY, False)
+async def tls_verify_dependency(context: Annotated[Context, TaskiqDepends()]) -> ssl.SSLContext | bool:
+    return getattr(context.state, STATE_TLS_VERIFY, True)
 
 
 async def session_dependency(context: Annotated[Context, TaskiqDepends()]) -> AsyncGenerator[AsyncSession, None]:

--- a/src/envoy/notification/main.py
+++ b/src/envoy/notification/main.py
@@ -9,8 +9,10 @@ from taskiq import TaskiqEvents, TaskiqState
 from envoy.notification.exception import NotificationError
 from envoy.notification.handler import (
     STATE_DB_SESSION_MAKER,
-    STATE_DISABLE_TLS_VERIFY,
     STATE_HREF_PREFIX,
+    STATE_TLS_VERIFY,
+    MtlsConfig,
+    build_tls_verify,
     generate_broker,
 )
 from envoy.notification.settings import generate_settings
@@ -65,7 +67,20 @@ async def startup(state: TaskiqState) -> None:
     db_engine = create_async_engine(db_cfg["db_url"], **engine_args)
     setattr(state, STATE_DB_SESSION_MAKER, async_sessionmaker(db_engine, expire_on_commit=False))
     setattr(state, STATE_HREF_PREFIX, settings.href_prefix)
-    setattr(state, STATE_DISABLE_TLS_VERIFY, settings.notification_disable_tls_verify)
+
+    mtls_config: MtlsConfig | None = None
+    if settings.notifications_with_mtls:
+        if not settings.notification_mtls_cert or not settings.notification_mtls_key:
+            raise NotificationError(
+                "NOTIFICATIONS_WITH_MTLS is enabled but NOTIFICATION_MTLS_CERT + NOTIFICATION_MTLS_KEY must both be set"
+            )
+        mtls_config = MtlsConfig(
+            cert_path=settings.notification_mtls_cert,
+            key_path=settings.notification_mtls_key,
+            serca_path=settings.notification_mtls_serca,
+        )
+    # Read the certificate files from disk into a reusable verify argument once, rather than per outbound request
+    setattr(state, STATE_TLS_VERIFY, build_tls_verify(settings.notification_disable_tls_verify, mtls_config))
 
 
 @broker.on_event(TaskiqEvents.WORKER_SHUTDOWN)

--- a/src/envoy/notification/settings.py
+++ b/src/envoy/notification/settings.py
@@ -10,6 +10,12 @@ class AppSettings(CommonSettings):
     version: str = importlib.metadata.version("envoy")
 
     notification_disable_tls_verify: bool = False  # Disable TLS cert verification for outbound notifications
+    notifications_with_mtls: bool = False  # Present a client certificate on outbound notification requests
+    notification_mtls_cert: str | None = None  # Path to client certificate PEM for outbound mTLS
+    notification_mtls_key: str | None = None  # Path to client private key PEM for outbound mTLS
+    notification_mtls_serca: str | None = (
+        None  # Path to SERCA PEM for verifying device server certs (None = system CAs)
+    )
 
 
 def generate_settings() -> AppSettings:

--- a/src/envoy/notification/task/transmit.py
+++ b/src/envoy/notification/task/transmit.py
@@ -1,4 +1,5 @@
 import logging
+import ssl
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Annotated
@@ -8,7 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from taskiq import AsyncBroker, TaskiqDepends, async_shared_broker
 
 from envoy.notification.exception import NotificationTransmitError
-from envoy.notification.handler import broker_dependency, disable_tls_verify_dependency, session_dependency
+from envoy.notification.handler import (
+    broker_dependency,
+    session_dependency,
+    tls_verify_dependency,
+)
 from envoy.server.api.response import SEP_XML_MIME
 from envoy.server.manager.time import utc_now
 from envoy.server.model.subscription import TransmitNotificationLog
@@ -125,17 +130,14 @@ async def do_transmit_notification(
     subscription_href: str,
     notification_id: str,
     attempt: int,
-    disable_tls_verify: bool = False,
+    verify: ssl.SSLContext | bool = True,
 ) -> TransmitResult:
     """Internal method for transmitting the notification - Raises a NotificationTransmitError if the request fails and
-    needs retrying otherwise returns TransmitResult indicating the final result"""
+    needs retrying otherwise returns TransmitResult indicating the final result.
 
-    # Big scary gotcha - There is no way (within the app layer) for a recipient of a notification
-    # to validate that it's coming from our utility server. The ONLY thing keeping us safe
-    # is the fact that CSIP recommends the use of mutual TLS which basically requires us to share our server
-    # cert with the listener. This is all handled out of band and will be noted in the client docs
-    # but I've put this message here for devs who read this code and get terrified. Good job on your keen security eye!
-    async with AsyncClient(timeout=TRANSMIT_TIMEOUT_SECONDS, verify=not disable_tls_verify) as client:
+    verify: The httpx "verify" argument (bool toggle or a prebuilt mTLS SSLContext) - see build_tls_verify"""
+
+    async with AsyncClient(timeout=TRANSMIT_TIMEOUT_SECONDS, verify=verify) as client:
         logger.debug(
             "Attempting to send notification %s of size %d to %s (attempt %d)",
             notification_id,
@@ -217,7 +219,7 @@ async def transmit_notification(
     attempt: int,
     broker: Annotated[AsyncBroker, TaskiqDepends(broker_dependency)] = TaskiqDepends(),
     session: Annotated[AsyncSession, TaskiqDepends(session_dependency)] = TaskiqDepends(),
-    disable_tls_verify: Annotated[bool, TaskiqDepends(disable_tls_verify_dependency)] = TaskiqDepends(),
+    verify: Annotated[ssl.SSLContext | bool, TaskiqDepends(tls_verify_dependency)] = TaskiqDepends(),
 ) -> None:
     """Call this to trigger an outgoing notification to be sent. If the notification fails it will be retried
     a few times (at a staggered cadence) before giving up.
@@ -235,7 +237,7 @@ async def transmit_notification(
             subscription_href,
             notification_id,
             attempt,
-            disable_tls_verify=disable_tls_verify,
+            verify=verify,
         )
         await safely_log_transmit_result(
             session=session, result=transmit_result, attempt=attempt, subscription_id=subscription_id, content=content

--- a/tests/unit/notification/task/test_transmit.py
+++ b/tests/unit/notification/task/test_transmit.py
@@ -1,3 +1,4 @@
+import ssl
 import unittest.mock as mock
 from datetime import UTC, datetime, timedelta
 from http import HTTPStatus
@@ -205,25 +206,16 @@ async def test_schedule_retry_transmission(
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("disable_tls_verify, expected_verify", [(False, True), (True, False)])
+@pytest.mark.parametrize("verify", [True, False, mock.MagicMock(spec=ssl.SSLContext)])
 @mock.patch("envoy.notification.task.transmit.AsyncClient")
-async def test_do_transmit_notification_tls_verify(
-    mock_AsyncClient: mock.MagicMock, disable_tls_verify: bool, expected_verify: bool
-):
-    """Tests that the disable_tls_verify flag is correctly passed through to AsyncClient as verify"""
+async def test_do_transmit_notification_passes_verify(mock_AsyncClient: mock.MagicMock, verify: ssl.SSLContext | bool):
+    """The prebuilt verify argument is passed straight through to AsyncClient"""
     mocked_client = MockedAsyncClient(Response(status_code=HTTPStatus.OK, content="Mock response content"))
     mock_AsyncClient.return_value = mocked_client
 
-    await do_transmit_notification(
-        "http://foo.bar/example",
-        "content",
-        "/sub/1",
-        str(uuid4()),
-        0,
-        disable_tls_verify=disable_tls_verify,
-    )
+    await do_transmit_notification("http://foo.bar/example", "content", "/sub/1", str(uuid4()), 0, verify=verify)
 
-    mock_AsyncClient.assert_called_once_with(timeout=mock.ANY, verify=expected_verify)
+    mock_AsyncClient.assert_called_once_with(timeout=mock.ANY, verify=verify)
 
 
 @pytest.mark.anyio
@@ -411,7 +403,7 @@ async def test_transmit_notification_no_retry(
         attempt,
         broker,
         session,
-        disable_tls_verify=False,
+        verify=True,
     )
 
     mock_safely_log_transmit_result.assert_called_once()
@@ -421,7 +413,7 @@ async def test_transmit_notification_no_retry(
         subscription_href,
         notification_id,
         attempt,
-        disable_tls_verify=False,
+        verify=True,
     )
     mock_schedule_retry_transmission.assert_not_called()
     assert_mock_session(session)
@@ -461,7 +453,7 @@ async def test_transmit_notification_with_retry(
         attempt,
         broker,
         session,
-        disable_tls_verify=False,
+        verify=True,
     )
 
     mock_safely_log_transmit_result.assert_called_once()
@@ -471,7 +463,7 @@ async def test_transmit_notification_with_retry(
         subscription_href,
         notification_id,
         attempt,
-        disable_tls_verify=False,
+        verify=True,
     )
     mock_schedule_retry_transmission.assert_called_once_with(
         broker, remote_uri, content, subscription_href, subscription_id, notification_id, attempt

--- a/tests/unit/notification/test_handler.py
+++ b/tests/unit/notification/test_handler.py
@@ -1,0 +1,45 @@
+import ssl
+import unittest.mock as mock
+
+import pytest
+
+from envoy.notification.handler import MtlsConfig, build_tls_verify
+
+
+@pytest.mark.parametrize("disable_tls_verify, expected_verify", [(False, True), (True, False)])
+def test_build_tls_verify_no_mtls(disable_tls_verify: bool, expected_verify: bool):
+    """Without mTLS the verify argument is just the inverse of disable_tls_verify"""
+    assert build_tls_verify(disable_tls_verify, None) is expected_verify
+
+
+@pytest.mark.parametrize(
+    "disable_tls_verify, serca_path, expect_cert_required, expect_load_verify",
+    [
+        (False, None, True, False),
+        (False, "/ca.pem", True, True),
+        (True, None, False, False),
+        (True, "/ca.pem", False, False),
+    ],
+)
+@mock.patch("envoy.notification.handler.ssl.SSLContext")
+def test_build_tls_verify_mtls_ssl_context(
+    mock_SSLContext: mock.MagicMock,
+    disable_tls_verify: bool,
+    serca_path: str | None,
+    expect_cert_required: bool,
+    expect_load_verify: bool,
+):
+    """With mTLS a properly configured SSLContext is built with the client certificate loaded from disk"""
+    mock_ctx = mock.MagicMock()
+    mock_SSLContext.return_value = mock_ctx
+
+    result = build_tls_verify(disable_tls_verify, MtlsConfig("/cert.pem", "/key.pem", serca_path))
+
+    assert result is mock_ctx
+    mock_ctx.load_cert_chain.assert_called_once_with(certfile="/cert.pem", keyfile="/key.pem")
+    assert mock_ctx.check_hostname is (not disable_tls_verify)
+    assert mock_ctx.verify_mode == (ssl.CERT_REQUIRED if expect_cert_required else ssl.CERT_NONE)
+    if expect_load_verify:
+        mock_ctx.load_verify_locations.assert_called_once_with(cafile="/ca.pem")
+    else:
+        mock_ctx.load_verify_locations.assert_not_called()


### PR DESCRIPTION
New certs on disk, build context once on startup. Config mimics that in cactus-client mostly.