### PR TITLE
Some changes as a result of connecting our sep2-client project

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -48,12 +48,12 @@ The underlying IEEE 2030.5 standard requires specially signed certificates to id
 | `testaggregator.crt` | Certificate for the client certificate registered to a testing "aggregator" |
 | `testaggregator.key` | Private Key for the client certificate registered to a testing "aggregator". No passphrase |
 | `testaggregator.p12` | PKCS#12/PFX, a convenient combination of the `testaggregator.crt` and `testaggregator.key`. Empty string passphrase |
- `testdevice1.crt` | Certificate for the client certificate registered to a testing non-aggregator "device" |
+| `testdevice1.crt` | Certificate for the client certificate registered to a testing non-aggregator "device" |
 | `testdevice1.key` | Private Key for the client certificate registered to a testing non-aggregator "device". No passphrase |
-| `testdevice1.p12` | PKCS#12/PFX, a convenient combination of the `testdevice.crt` and `testdevice.key`. Empty string passphrase |
-`testdevice2.crt` | Certificate for the client certificate registered to a testing non-aggregator "device" |
+| `testdevice1.p12` | PKCS#12/PFX, a convenient combination of the `testdevice1.crt` and `testdevice1.key`. Empty string passphrase |
+| `testdevice2.crt` | Certificate for the client certificate registered to a testing non-aggregator "device" |
 | `testdevice2.key` | Private Key for the client certificate registered to a testing non-aggregator "device". No passphrase |
-| `testdevice2.p12` | PKCS#12/PFX, a convenient combination of the `testdevice.crt` and `testdevice.key`. Empty string passphrase |
+| `testdevice2.p12` | PKCS#12/PFX, a convenient combination of the `testdevice2.crt` and `testdevice2.key`. Empty string passphrase |
 
 The client certificates described in the table above are signed by the test CA and can be used against the nginx instance exposed on port 8443.
 
@@ -64,7 +64,7 @@ You are welcome to sign additional certificates using the "test ca", but please 
 The easiest way to validate that the example services have started is by issuing a HTTPS request to localhost:8443/dcap
 
 ```
-curl --cacert ./tls-termination/test_certs/testca.crt --cert ./tls-termination/test_certs/testdevice.p12:testclientpassphrase --cert-type p12 https://localhost:8443/dcap
+curl --cacert ./tls-termination/test_certs/testca.crt --cert ./tls-termination/test_certs/testdevice1.p12: --cert-type p12 https://localhost:8443/dcap
 ```
 
 That should generate a response like this:
@@ -79,7 +79,7 @@ In the root repository directory under `postman/` you'll find Postman collection
 You'll need to import them and then do the following:
 1. File -> Settings -> Certificates -> Client Certificates -> Add Certificate
     * Set the certificate host to `https://localhost:8443`
-    * Set the PFX file to `testdevice.p12` (see table above for other info)
+    * Set the PFX file to `testdevice1.p12` (see table above for other info)
 2. envoy collection -> Variables
     * Set HOST to `localhost:8443`
 

--- a/demo/tls-termination/Dockerfile
+++ b/demo/tls-termination/Dockerfile
@@ -3,8 +3,10 @@ FROM nginx:bookworm
 ARG HOST_UID
 ARG HOST_GID
 
-RUN usermod -u $HOST_UID www-data && \
-    groupmod -g $HOST_GID www-data
+RUN if [ -n "$HOST_UID" ] && [ -n "$HOST_GID" ]; then \
+        groupmod -o -g "$HOST_GID" www-data && \
+        usermod -u "$HOST_UID" www-data; \
+    fi
 
 COPY --chown=www-data:www-data ./nginx.conf /etc/nginx/nginx.conf
 COPY --chown=www-data:www-data --chmod=770 ./entrypoint/* /

--- a/demo/tls-termination/entrypoint/san.conf
+++ b/demo/tls-termination/entrypoint/san.conf
@@ -14,3 +14,4 @@ subjectAltName = @alt_names
 DNS.1 = device
 DNS.2 = admin
 DNS.3 = localhost
+IP.1 = 127.0.0.1

--- a/demo/tls-termination/entrypoint/tls-setup.sh
+++ b/demo/tls-termination/entrypoint/tls-setup.sh
@@ -66,9 +66,17 @@ if ! [ -d "$RPROXY_CERTS_DIR" ]; then
 fi
 
 # Check if rproxy certs exist, generate if not
-if ! [ -f "$RPROXY_CERTS_DIR/testrproxy.crt" ]; then
-    openssl req -new -nodes -keyout "$RPROXY_CERTS_DIR/testrproxy.key" -out "$RPROXY_CERTS_DIR/testrproxy.csr" -config /san.conf
-    openssl x509 -req -days 365 -in "$RPROXY_CERTS_DIR/testrproxy.csr" -CA "$CERTS_DIR/testca.crt" \
-        -CAkey "$CERTS_DIR/testca.key" -set_serial 01 -out "$RPROXY_CERTS_DIR/testrproxy.crt" \
+if ! [ -f "$RPROXY_CERTS_DIR/testrproxy-rsa.crt" ] || ! [ -f "$RPROXY_CERTS_DIR/testrproxy-rsa.key" ]; then
+    openssl req -new -nodes -keyout "$RPROXY_CERTS_DIR/testrproxy-rsa.key" -out "$RPROXY_CERTS_DIR/testrproxy-rsa.csr" -config /san.conf
+    openssl x509 -req -days 365 -in "$RPROXY_CERTS_DIR/testrproxy-rsa.csr" -CA "$CERTS_DIR/testca.crt" \
+        -CAkey "$CERTS_DIR/testca.key" -set_serial 01 -out "$RPROXY_CERTS_DIR/testrproxy-rsa.crt" \
+        -extfile /san.conf -extensions v3_req
+fi
+
+if ! [ -f "$RPROXY_CERTS_DIR/testrproxy-ecdsa.crt" ] || ! [ -f "$RPROXY_CERTS_DIR/testrproxy-ecdsa.key" ]; then
+    openssl ecparam -name prime256v1 -genkey -noout -out "$RPROXY_CERTS_DIR/testrproxy-ecdsa.key"
+    openssl req -new -key "$RPROXY_CERTS_DIR/testrproxy-ecdsa.key" -out "$RPROXY_CERTS_DIR/testrproxy-ecdsa.csr" -config /san.conf
+    openssl x509 -req -days 365 -in "$RPROXY_CERTS_DIR/testrproxy-ecdsa.csr" -CA "$CERTS_DIR/testca.crt" \
+        -CAkey "$CERTS_DIR/testca.key" -set_serial 02 -out "$RPROXY_CERTS_DIR/testrproxy-ecdsa.crt" \
         -extfile /san.conf -extensions v3_req
 fi

--- a/demo/tls-termination/nginx.conf
+++ b/demo/tls-termination/nginx.conf
@@ -32,8 +32,10 @@ http {
 
         server_name localhost device;
         proxy_ssl_server_name on;
-        ssl_certificate      /tmp/rproxy_certs/testrproxy.crt;
-        ssl_certificate_key /tmp/rproxy_certs/testrproxy.key;
+        ssl_certificate      /tmp/rproxy_certs/testrproxy-rsa.crt;
+        ssl_certificate_key /tmp/rproxy_certs/testrproxy-rsa.key;
+        ssl_certificate      /tmp/rproxy_certs/testrproxy-ecdsa.crt;
+        ssl_certificate_key /tmp/rproxy_certs/testrproxy-ecdsa.key;
         ssl_client_certificate /tmp/certs/testca.crt;
 
         ssl_verify_client on;
@@ -74,8 +76,10 @@ AES128-SHA:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:AES128-GCM-SHA256:AES256-GCM
 
         server_name admin;
         proxy_ssl_server_name on;
-        ssl_certificate      /tmp/rproxy_certs/testrproxy.crt;
-        ssl_certificate_key /tmp/rproxy_certs/testrproxy.key;
+        ssl_certificate      /tmp/rproxy_certs/testrproxy-rsa.crt;
+        ssl_certificate_key /tmp/rproxy_certs/testrproxy-rsa.key;
+        ssl_certificate      /tmp/rproxy_certs/testrproxy-ecdsa.crt;
+        ssl_certificate_key /tmp/rproxy_certs/testrproxy-ecdsa.key;
 
         ssl_verify_client off;
 


### PR DESCRIPTION
Changes in support of our recent development activities:

* Permits the demo to run without a hitch on macOS
* Permits the Subject Alternative Name to be the loopback IP for the demo. We often connect locally.
* Generates ECDSA certificates in addition to the RSA certificates previously generated. This is so sep2 clients that strictly confirm with 2030.5's requirements for ECDHE-ECDSA-AES128-CCM can run with the demo.