### PR TITLE
fix(notification): load system CA roots for mTLS callbacks

### DIFF
--- a/src/envoy/notification/handler.py
+++ b/src/envoy/notification/handler.py
@@ -26,7 +26,9 @@ def build_tls_verify(disable_tls_verify: bool, mtls_config: MtlsConfig | None) -
     if mtls_config is None:
         return not disable_tls_verify
 
-    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    # SSLContext(PROTOCOL_TLS_CLIENT) 的信任库初始为空。回调目标可能使用公共 CA，
+    # 因此先加载系统 CA 信任库；仅在配置 SERCA 时再追加其证书。
+    ssl_context = ssl.create_default_context()
     ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
     ssl_context.set_ciphers("ECDHE-ECDSA-AES128-CCM8:ALL:!aNULL")
     if disable_tls_verify:

--- a/tests/unit/notification/test_handler.py
+++ b/tests/unit/notification/test_handler.py
@@ -21,9 +21,9 @@ def test_build_tls_verify_no_mtls(disable_tls_verify: bool, expected_verify: boo
         (True, "/ca.pem", False, False),
     ],
 )
-@mock.patch("envoy.notification.handler.ssl.SSLContext")
+@mock.patch("envoy.notification.handler.ssl.create_default_context")
 def test_build_tls_verify_mtls_ssl_context(
-    mock_SSLContext: mock.MagicMock,
+    mock_create_default_context: mock.MagicMock,
     disable_tls_verify: bool,
     serca_path: str | None,
     expect_cert_required: bool,
@@ -31,11 +31,12 @@ def test_build_tls_verify_mtls_ssl_context(
 ):
     """With mTLS a properly configured SSLContext is built with the client certificate loaded from disk"""
     mock_ctx = mock.MagicMock()
-    mock_SSLContext.return_value = mock_ctx
+    mock_create_default_context.return_value = mock_ctx
 
     result = build_tls_verify(disable_tls_verify, MtlsConfig("/cert.pem", "/key.pem", serca_path))
 
     assert result is mock_ctx
+    mock_create_default_context.assert_called_once_with()
     mock_ctx.load_cert_chain.assert_called_once_with(certfile="/cert.pem", keyfile="/key.pem")
     assert mock_ctx.check_hostname is (not disable_tls_verify)
     assert mock_ctx.verify_mode == (ssl.CERT_REQUIRED if expect_cert_required else ssl.CERT_NONE)


### PR DESCRIPTION
## Summary

Fix mTLS callback verification for recipients using publicly trusted TLS certificates.

`ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)` starts with an empty trust store. As a result, mTLS callbacks to endpoints using public CAs (for example, DigiCert or Let's Encrypt) can fail with `CERTIFICATE_VERIFY_FAILED`.

## Changes

- Initialise the mTLS client context with `ssl.create_default_context()` to load system CA roots.
- Preserve optional SERCA loading via `load_verify_locations()`.
- Preserve client certificate/key loading via `load_cert_chain()`.
- Update unit tests to verify use of the default system trust store.

## Validation

- `pytest tests/unit/notification/test_handler.py` — 6 passed
- `ruff check --no-cache .` — passed
- `bandit -r src` — passed
- `ty check src/envoy/notification/handler.py tests/unit/notification/test_handler.py` — passed

> Note: a full-repository `ty check` reports existing diagnostics in unrelated test/settings files; this change introduces no new type-checking diagnostics.

## Scope

No callback URLs, TLS versions, cipher configuration, or existing SERCA behaviour are changed.