### PR TITLE
SiteGroup defaults and restrictions on TariffProfile/DERProgram

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ name = "envoy"
 dynamic = ["version", "readme"]
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    "envoy_schema==1.2.2",
+    "envoy_schema==1.2.3",
     "fastapi>=0.94.1,<0.137", # Recent FastAPI versions appear to break route exclusion functionality
     "sqlalchemy>=2.0.0",
     "alembic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ name = "envoy"
 dynamic = ["version", "readme"]
 requires-python = ">=3.11,<4.0"
 dependencies = [
-    "envoy_schema==1.2.1",
+    "envoy_schema==1.2.2",
     "fastapi>=0.94.1,<0.137", # Recent FastAPI versions appear to break route exclusion functionality
     "sqlalchemy>=2.0.0",
     "alembic",

--- a/src/envoy/admin/crud/pricing.py
+++ b/src/envoy/admin/crud/pricing.py
@@ -29,6 +29,7 @@ async def update_single_tariff(session: AsyncSession, updated_tariff: Tariff) ->
     tariff.dnsp_code = updated_tariff.dnsp_code
     tariff.name = updated_tariff.name
     tariff.currency_code = updated_tariff.currency_code
+    tariff.required_site_group_id = updated_tariff.required_site_group_id
     tariff.fsa_id = updated_tariff.fsa_id
 
 

--- a/src/envoy/admin/manager/site_control.py
+++ b/src/envoy/admin/manager/site_control.py
@@ -87,6 +87,7 @@ class SiteControlGroupManager:
 
         existing_scg.description = updated_scg.description
         existing_scg.primacy = updated_scg.primacy
+        existing_scg.required_site_group_id = updated_scg.required_site_group_id
         existing_scg.changed_time = now
 
         # Archive the current record BEFORE we apply the new changes

--- a/src/envoy/admin/mapper/pricing.py
+++ b/src/envoy/admin/mapper/pricing.py
@@ -14,6 +14,7 @@ class TariffMapper:
             currency_code=tariff.currency_code,
             dnsp_code=tariff.dnsp_code,
             fsa_id=tariff.fsa_id,
+            required_site_group_id=tariff.required_site_group_id,
         )
 
     @staticmethod

--- a/src/envoy/admin/mapper/site.py
+++ b/src/envoy/admin/mapper/site.py
@@ -223,6 +223,7 @@ class SiteGroupMapper:
             name=group.name,
             created_time=group.created_time,
             changed_time=group.changed_time,
+            default_group=group.default_group,
             total_sites=site_count,
         )
 

--- a/src/envoy/admin/mapper/site_control.py
+++ b/src/envoy/admin/mapper/site_control.py
@@ -22,6 +22,7 @@ class SiteControlGroupListMapper:
             changed_time=changed_time,
             fsa_id=request.fsa_id,
             display_id=request.display_id,
+            required_site_group_id=request.required_site_group_id,
         )
 
     @staticmethod
@@ -34,6 +35,7 @@ class SiteControlGroupListMapper:
             changed_time=site_control_group.changed_time,
             fsa_id=site_control_group.fsa_id,
             display_id=site_control_group.display_id,
+            required_site_group_id=site_control_group.required_site_group_id,
         )
 
     @staticmethod

--- a/src/envoy/notification/crud/batch.py
+++ b/src/envoy/notification/crud/batch.py
@@ -58,7 +58,7 @@ from envoy.server.model.site import (
 )
 from envoy.server.model.site_reading import SiteReading, SiteReadingType
 from envoy.server.model.subscription import Subscription, SubscriptionResource
-from envoy.server.model.tariff import TariffGeneratedRate
+from envoy.server.model.tariff import Tariff, TariffGeneratedRate
 
 
 class AggregatorBatchedEntities(Generic[TResourceModel, TArchiveResourceModel]):
@@ -327,13 +327,52 @@ async def fetch_rates_by_changed_at(
         for site_group_id, aggregator_id, site_id, timezone_id in member_sites:
             member_sites_by_group_id.setdefault(site_group_id, []).append((aggregator_id, site_id, timezone_id))
 
+    # A rate's parent Tariff can also restrict visibility via required_site_group_id - resolve each referenced
+    # Tariff's requirement (if any) and the membership of whatever SiteGroup it requires
+    referenced_tariff_ids = {
+        e.tariff_id
+        for e in cast(Iterable[TariffGeneratedRate | ArchiveTariffGeneratedRate], chain(active_rates, deleted_rates))
+    }
+    required_group_by_tariff_id: dict[int, int | None] = {}
+    if referenced_tariff_ids:
+        tariff_rows = (
+            await session.execute(
+                select(Tariff.tariff_id, Tariff.required_site_group_id).where(
+                    Tariff.tariff_id.in_(referenced_tariff_ids)
+                )
+            )
+        ).tuples()
+        required_group_by_tariff_id = dict(tariff_rows.all())
+
+    referenced_required_group_ids = {gid for gid in required_group_by_tariff_id.values() if gid is not None}
+    member_site_ids_by_required_group: dict[int, set[int]] = {}
+    if referenced_required_group_ids:
+        required_members = (
+            await session.execute(
+                select(SiteGroupAssignment.site_group_id, SiteGroupAssignment.site_id).where(
+                    SiteGroupAssignment.site_group_id.in_(referenced_required_group_ids)
+                )
+            )
+        ).all()
+        for site_group_id, site_id in required_members:
+            member_site_ids_by_required_group.setdefault(site_group_id, set()).add(site_id)
+
     def expand_rate(rate: TariffGeneratedRate | ArchiveTariffGeneratedRate) -> list[tuple[int, int, Any]]:
         """Expands a single rate into one (aggregator_id, site_id, localized_rate) tuple per member site of its
         SiteGroup. Each site gets its own copy of rate since start_time localization mutates in place and
-        different member sites can be in different timezones."""
+        different member sites can be in different timezones.
+
+        A member site is excluded if the rate's parent Tariff has a required_site_group_id set and the site isn't
+        a member of that SiteGroup (Tariff.required_site_group_id not found - eg the Tariff itself has been
+        deleted - is treated as unrestricted, since there's no requirement left to enforce)."""
+        required_group_id = required_group_by_tariff_id.get(rate.tariff_id)
+        allowed_site_ids = (
+            None if required_group_id is None else member_site_ids_by_required_group.get(required_group_id, set())
+        )
         return [
             (aggregator_id, site_id, localize_start_time_for_entity(copy.copy(rate), timezone_id))
             for aggregator_id, site_id, timezone_id in member_sites_by_group_id.get(rate.site_group_id, [])
+            if allowed_site_ids is None or site_id in allowed_site_ids
         ]
 
     site_scoped_active_rates = [
@@ -711,18 +750,49 @@ async def fetch_site_control_groups_by_changed_at(
         return AggregatorBatchedEntities(timestamp, SubscriptionResource.SITE_CONTROL_GROUP, [], [])
 
     # The site control group update will need to vary per Site so we generate an instance per site_id
-    aggregator_site_ids = (await session.execute(select(Site.aggregator_id, Site.site_id).order_by(Site.site_id))).all()
+    aggregator_site_ids = (
+        (await session.execute(select(Site.aggregator_id, Site.site_id).order_by(Site.site_id))).tuples().all()
+    )
+
+    # Groups with a required_site_group_id set are only visible to member sites of that group - resolve
+    # membership for any such groups referenced in this batch
+    referenced_required_group_ids = {
+        g.required_site_group_id
+        for g in cast(Iterable[SiteControlGroup | ArchiveSiteControlGroup], chain(active_groups, deleted_groups))
+        if g.required_site_group_id is not None
+    }
+    member_site_ids_by_required_group: dict[int, set[int]] = {}
+    if referenced_required_group_ids:
+        members = (
+            await session.execute(
+                select(SiteGroupAssignment.site_group_id, SiteGroupAssignment.site_id).where(
+                    SiteGroupAssignment.site_group_id.in_(referenced_required_group_ids)
+                )
+            )
+        ).all()
+        for site_group_id, site_id in members:
+            member_site_ids_by_required_group.setdefault(site_group_id, set()).add(site_id)
+
+    def visible_aggregator_site_ids(
+        group: SiteControlGroup | ArchiveSiteControlGroup,
+    ) -> Sequence[tuple[int, int]]:
+        """Returns the (aggregator_id, site_id) pairs that should be notified about group - all sites, unless
+        group.required_site_group_id restricts visibility to a specific SiteGroup's members."""
+        if group.required_site_group_id is None:
+            return aggregator_site_ids
+        member_site_ids = member_site_ids_by_required_group.get(group.required_site_group_id, set())
+        return [(agg_id, site_id) for agg_id, site_id in aggregator_site_ids if site_id in member_site_ids]
 
     site_scoped_active_groups: list[SiteScopedSiteControlGroup] = [
         SiteScopedSiteControlGroup(agg_id, site_id, active_group)
-        for agg_id, site_id in aggregator_site_ids
         for active_group in active_groups
+        for agg_id, site_id in visible_aggregator_site_ids(active_group)
     ]
 
     site_scoped_deleted_groups = [
         ArchiveSiteScopedSiteControlGroup(agg_id, site_id, deleted_group)
-        for agg_id, site_id in aggregator_site_ids
         for deleted_group in deleted_groups
+        for agg_id, site_id in visible_aggregator_site_ids(deleted_group)
     ]
 
     return AggregatorBatchedEntities(

--- a/src/envoy/server/alembic/versions/221e711a4555_required_site_group.py
+++ b/src/envoy/server/alembic/versions/221e711a4555_required_site_group.py
@@ -1,0 +1,56 @@
+"""required_site_group
+
+Revision ID: 221e711a4555
+Revises: ab6361a582b3
+Create Date: 2026-07-29 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "221e711a4555"
+down_revision = "ab6361a582b3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("site_control_group", sa.Column("required_site_group_id", sa.Integer(), nullable=True))
+    op.create_index(
+        op.f("ix_site_control_group_required_site_group_id"),
+        "site_control_group",
+        ["required_site_group_id"],
+        unique=False,
+    )
+    op.create_foreign_key(
+        "site_control_group_required_site_group_id_fkey",
+        "site_control_group",
+        "site_group",
+        ["required_site_group_id"],
+        ["site_group_id"],
+    )
+    op.add_column("archive_site_control_group", sa.Column("required_site_group_id", sa.Integer(), nullable=True))
+
+    op.add_column("tariff", sa.Column("required_site_group_id", sa.Integer(), nullable=True))
+    op.create_index(op.f("ix_tariff_required_site_group_id"), "tariff", ["required_site_group_id"], unique=False)
+    op.create_foreign_key(
+        "tariff_required_site_group_id_fkey",
+        "tariff",
+        "site_group",
+        ["required_site_group_id"],
+        ["site_group_id"],
+    )
+    op.add_column("archive_tariff", sa.Column("required_site_group_id", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("archive_tariff", "required_site_group_id")
+    op.drop_constraint("tariff_required_site_group_id_fkey", "tariff", type_="foreignkey")
+    op.drop_index(op.f("ix_tariff_required_site_group_id"), table_name="tariff")
+    op.drop_column("tariff", "required_site_group_id")
+
+    op.drop_column("archive_site_control_group", "required_site_group_id")
+    op.drop_constraint("site_control_group_required_site_group_id_fkey", "site_control_group", type_="foreignkey")
+    op.drop_index(op.f("ix_site_control_group_required_site_group_id"), table_name="site_control_group")
+    op.drop_column("site_control_group", "required_site_group_id")

--- a/src/envoy/server/alembic/versions/221e711a4555_required_site_group.py
+++ b/src/envoy/server/alembic/versions/221e711a4555_required_site_group.py
@@ -17,6 +17,7 @@ depends_on = None
 
 def upgrade() -> None:
     op.add_column("site_control_group", sa.Column("required_site_group_id", sa.Integer(), nullable=True))
+
     op.create_index(
         op.f("ix_site_control_group_required_site_group_id"),
         "site_control_group",
@@ -43,8 +44,17 @@ def upgrade() -> None:
     )
     op.add_column("archive_tariff", sa.Column("required_site_group_id", sa.Integer(), nullable=True))
 
+    op.add_column(
+        "site_group",
+        sa.Column("default_group", sa.BOOLEAN(), nullable=False, server_default="false"),
+    )
+    op.create_index(op.f("ix_site_group_default_group"), "site_group", ["default_group"], unique=False)
+
 
 def downgrade() -> None:
+    op.drop_index(op.f("ix_site_group_default_group"), table_name="site_group")
+    op.drop_column("site_group", "default_group")
+
     op.drop_column("archive_tariff", "required_site_group_id")
     op.drop_constraint("tariff_required_site_group_id_fkey", "tariff", type_="foreignkey")
     op.drop_index(op.f("ix_tariff_required_site_group_id"), table_name="tariff")

--- a/src/envoy/server/crud/doe.py
+++ b/src/envoy/server/crud/doe.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.sql import ColumnElement
 
 from envoy.server.crud.common import localize_start_time, localize_start_time_for_entity
+from envoy.server.crud.site_group import required_site_group_visible_to_site
 from envoy.server.crud.site_group import site_group_membership_exists as _site_group_membership_exists
 from envoy.server.crud.site_group import site_is_member_of_group as _site_is_member_of_group
 from envoy.server.model.archive.doe import ArchiveDynamicOperatingEnvelope as ArchiveDOE
@@ -449,8 +450,13 @@ async def _site_control_groups(
     limit: int | None,
     fsa_id: int | None,
     include_defaults: bool,
+    site_id: int | None = None,
 ) -> Sequence[SiteControlGroup] | int:
     """Internal utility for fetching/counting SiteControlGroup's
+
+    site_id: If specified, hides any SiteControlGroup whose required_site_group_id is set and doesn't include
+        site_id as a member (via SiteGroupAssignment). If None, no visibility filtering is applied (eg for admin
+        use, which should see every SiteControlGroup regardless of visibility restrictions).
 
     Orders by 2030.5 requirements on DERProgram which is primacy ASC, primary key DESC"""
 
@@ -465,6 +471,9 @@ async def _site_control_groups(
 
     if fsa_id is not None:
         stmt = stmt.where(SiteControlGroup.fsa_id == fsa_id)
+
+    if site_id is not None:
+        stmt = stmt.where(required_site_group_visible_to_site(SiteControlGroup.required_site_group_id, site_id))
 
     if not is_counting:
         stmt = stmt.order_by(SiteControlGroup.primacy.asc(), SiteControlGroup.site_control_group_id.desc())
@@ -486,21 +495,30 @@ async def select_site_control_groups(
     limit: int | None,
     fsa_id: int | None,
     include_defaults: bool = False,
+    site_id: int | None = None,
 ) -> Sequence[SiteControlGroup]:
     """Fetches SiteControlGroup with some basic pagination / filtering on change time.
 
     if fsa_id is specified - only SiteControlGroups with this fsa_id value will be returned
 
+    site_id: If specified, hides any SiteControlGroup whose required_site_group_id is set and doesn't include
+        site_id as a member. If None, no visibility filtering is applied.
+
     Orders by 2030.5 requirements on DERProgram which is primacy ASC, primary key DESC"""
 
     # Test coverage will ensure that it's an entity list
-    return await _site_control_groups(False, session, start, changed_after, limit, fsa_id, include_defaults)  # ty:ignore[invalid-return-type]
+    return await _site_control_groups(False, session, start, changed_after, limit, fsa_id, include_defaults, site_id)  # ty:ignore[invalid-return-type]
 
 
-async def count_site_control_groups(session: AsyncSession, changed_after: datetime, fsa_id: int | None) -> int:
+async def count_site_control_groups(
+    session: AsyncSession, changed_after: datetime, fsa_id: int | None, site_id: int | None = None
+) -> int:
     """Counts SiteControlGroups that have been modified after the specified change time.
 
     if fsa_id is specified - only SiteControlGroups with this fsa_id value will be counted
+
+    site_id: If specified, hides any SiteControlGroup whose required_site_group_id is set and doesn't include
+        site_id as a member. If None, no visibility filtering is applied.
     """
 
     # Test coverage will ensure that it's an int
@@ -512,6 +530,7 @@ async def count_site_control_groups(session: AsyncSession, changed_after: dateti
         None,
         fsa_id,
         False,
+        site_id,
     )  # ty:ignore[invalid-return-type]
 
 
@@ -535,11 +554,17 @@ async def count_site_control_groups_by_fsa_id(session: AsyncSession) -> dict[int
 
 
 async def select_site_control_group_by_id(
-    session: AsyncSession, site_control_group_id: int, include_default: bool = False
+    session: AsyncSession, site_control_group_id: int, include_default: bool = False, site_id: int | None = None
 ) -> SiteControlGroup | None:
-    """Fetches a single SiteControlGroup with the specified site_control_group_id. Returns None if it can't be found."""
+    """Fetches a single SiteControlGroup with the specified site_control_group_id. Returns None if it can't be found.
+
+    site_id: If specified, returns None if the SiteControlGroup's required_site_group_id is set and doesn't
+        include site_id as a member. If None, no visibility filtering is applied (eg for admin use)."""
 
     stmt = select(SiteControlGroup).where(SiteControlGroup.site_control_group_id == site_control_group_id).limit(1)
+
+    if site_id is not None:
+        stmt = stmt.where(required_site_group_visible_to_site(SiteControlGroup.required_site_group_id, site_id))
 
     if include_default:
         stmt = stmt.options(selectinload(SiteControlGroup.site_control_group_default))

--- a/src/envoy/server/crud/pricing.py
+++ b/src/envoy/server/crud/pricing.py
@@ -7,7 +7,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import ColumnElement
 
 from envoy.server.crud.common import localize_start_time, localize_start_time_for_entity
-from envoy.server.crud.site_group import site_group_membership_exists, site_is_member_of_group
+from envoy.server.crud.site_group import (
+    required_site_group_visible_to_site,
+    site_group_membership_exists,
+    site_is_member_of_group,
+)
 from envoy.server.model.site import Site, SiteGroupAssignment
 from envoy.server.model.tariff import Tariff, TariffGeneratedRate
 
@@ -23,11 +27,15 @@ async def select_tariff_fsa_ids(session: AsyncSession, changed_after: datetime) 
     return resp.scalars().all()
 
 
-async def select_tariff_count(session: AsyncSession, after: datetime, fsa_id: int | None) -> int:
+async def select_tariff_count(
+    session: AsyncSession, after: datetime, fsa_id: int | None, site_id: int | None = None
+) -> int:
     """Fetches the number of tariffs stored
 
     after: Only tariffs with a changed_time greater than this value will be counted (set to 0 to count everything)
-    fsa_id: If specified - only count Tariffs with this value for fsa_id"""
+    fsa_id: If specified - only count Tariffs with this value for fsa_id
+    site_id: If specified, hides any Tariff whose required_site_group_id is set and doesn't include site_id as a
+        member. If None, no visibility filtering is applied (eg for admin use)."""
 
     # At the moment tariff's are exposed to all aggregators - the plan is for them to be scoped for individual
     # groups of sites but this could be subject to change as the DNSP's requirements become more clear
@@ -39,12 +47,20 @@ async def select_tariff_count(session: AsyncSession, after: datetime, fsa_id: in
     if fsa_id is not None:
         stmt = stmt.where(Tariff.fsa_id == fsa_id)
 
+    if site_id is not None:
+        stmt = stmt.where(required_site_group_visible_to_site(Tariff.required_site_group_id, site_id))
+
     resp = await session.execute(stmt)
     return resp.scalar_one()
 
 
 async def select_all_tariffs(
-    session: AsyncSession, start: int, changed_after: datetime, limit: int, fsa_id: int | None
+    session: AsyncSession,
+    start: int,
+    changed_after: datetime,
+    limit: int,
+    fsa_id: int | None,
+    site_id: int | None = None,
 ) -> Sequence[Tariff]:
     """Selects tariffs with some basic pagination / filtering based on change time
 
@@ -53,7 +69,9 @@ async def select_all_tariffs(
     start: The number of matching entities to skip
     limit: The maximum number of entities to return
     changed_after: removes any entities with a changed_date BEFORE this value (set to datetime.min to not filter)
-    fsa_id: If specified - only include Tariffs with this value for fsa_id"""
+    fsa_id: If specified - only include Tariffs with this value for fsa_id
+    site_id: If specified, hides any Tariff whose required_site_group_id is set and doesn't include site_id as a
+        member. If None, no visibility filtering is applied (eg for admin use)."""
 
     # At the moment tariff's are exposed to all aggregators - the plan is for them to be scoped for individual
     # groups of sites but this could be subject to change as the DNSP's requirements become more clear
@@ -72,16 +90,25 @@ async def select_all_tariffs(
     if fsa_id is not None:
         stmt = stmt.where(Tariff.fsa_id == fsa_id)
 
+    if site_id is not None:
+        stmt = stmt.where(required_site_group_visible_to_site(Tariff.required_site_group_id, site_id))
+
     resp = await session.execute(stmt)
     return resp.scalars().all()
 
 
-async def select_single_tariff(session: AsyncSession, tariff_id: int) -> Tariff | None:
-    """Requests a single tariff based on the primary key - returns None if it does not exist"""
+async def select_single_tariff(session: AsyncSession, tariff_id: int, site_id: int | None = None) -> Tariff | None:
+    """Requests a single tariff based on the primary key - returns None if it does not exist
+
+    site_id: If specified, returns None if the Tariff's required_site_group_id is set and doesn't include site_id
+        as a member. If None, no visibility filtering is applied (eg for admin use)."""
 
     # At the moment tariff's are exposed to all aggregators - the plan is for them to be scoped for individual
     # groups of sites but this could be subject to change as the DNSP's requirements become more clear
     stmt = select(Tariff).where(Tariff.tariff_id == tariff_id)
+
+    if site_id is not None:
+        stmt = stmt.where(required_site_group_visible_to_site(Tariff.required_site_group_id, site_id))
 
     resp = await session.execute(stmt)
     return resp.scalar_one_or_none()

--- a/src/envoy/server/crud/site_group.py
+++ b/src/envoy/server/crud/site_group.py
@@ -1,9 +1,12 @@
+from datetime import datetime
+
 from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.sql.selectable import Exists
 
-from envoy.server.model.site import Site, SiteGroupAssignment
+from envoy.server.model.site import Site, SiteGroup, SiteGroupAssignment
 
 
 def site_is_member_of_group(site_group_id_col: InstrumentedAttribute[int], site_id: int) -> Exists:
@@ -58,3 +61,19 @@ def required_site_group_visible_to_site(
         .exists()
     )
     return or_(required_site_group_id_col.is_(None), member_exists)
+
+
+async def assign_default_site_groups_to_site(session: AsyncSession, site_id: int, changed_time: datetime) -> None:
+    """Adds a SiteGroupAssignment linking site_id to every SiteGroup marked as default_group=True. Intended to be
+    called immediately after a new Site is created so it automatically becomes a member of the "default" groups.
+
+    Does not flush/commit - it's expected the caller will do so as part of the enclosing transaction."""
+
+    default_group_ids = (
+        (await session.execute(select(SiteGroup.site_group_id).where(SiteGroup.default_group.is_(True))))
+        .scalars()
+        .all()
+    )
+
+    for site_group_id in default_group_ids:
+        session.add(SiteGroupAssignment(site_id=site_id, site_group_id=site_group_id, changed_time=changed_time))

--- a/src/envoy/server/crud/site_group.py
+++ b/src/envoy/server/crud/site_group.py
@@ -1,4 +1,4 @@
-from sqlalchemy import and_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql import ColumnElement
 from sqlalchemy.sql.selectable import Exists
@@ -38,3 +38,23 @@ def site_group_membership_exists(
         conditions.append(SiteGroupAssignment.site_id == site_id)
 
     return stmt.where(and_(*conditions)).exists()
+
+
+def required_site_group_visible_to_site(
+    required_site_group_id_col: InstrumentedAttribute[int | None], site_id: int
+) -> ColumnElement[bool]:
+    """Builds a filter clause for an optional "required_site_group_id" column (SiteControlGroup/Tariff): True if
+    the column is NULL (no restriction - globally visible) or if site_id is a member (via SiteGroupAssignment) of
+    the SiteGroup it references.
+
+    Never joins against the enclosing statement, so an entity row can never fan out into multiple result rows
+    regardless of how many sites are in the required SiteGroup."""
+
+    member_exists = (
+        select(SiteGroupAssignment.site_group_assignment_id)
+        .where(
+            (SiteGroupAssignment.site_group_id == required_site_group_id_col) & (SiteGroupAssignment.site_id == site_id)
+        )
+        .exists()
+    )
+    return or_(required_site_group_id_col.is_(None), member_exists)

--- a/src/envoy/server/manager/derp.py
+++ b/src/envoy/server/manager/derp.py
@@ -57,9 +57,17 @@ class DERProgramManager:
         config = await RuntimeServerConfigManager.fetch_current_config(session)
 
         site_control_groups = await select_site_control_groups(
-            session, start=start, limit=limit, changed_after=changed_after, fsa_id=fsa_id, include_defaults=True
+            session,
+            start=start,
+            limit=limit,
+            changed_after=changed_after,
+            fsa_id=fsa_id,
+            include_defaults=True,
+            site_id=site.site_id,
         )
-        site_control_group_count = await count_site_control_groups(session, changed_after, fsa_id=fsa_id)
+        site_control_group_count = await count_site_control_groups(
+            session, changed_after, fsa_id=fsa_id, site_id=site.site_id
+        )
         control_counts_by_group: list[tuple[SiteControlGroup, int]] = []
         for group in site_control_groups:
             control_counts_by_group.append(
@@ -97,7 +105,9 @@ class DERProgramManager:
         if not site:
             raise NotFoundError(f"site_id {scope.site_id} is not accessible / does not exist")
 
-        site_control_group = await select_site_control_group_by_id(session, der_program_id, include_default=True)
+        site_control_group = await select_site_control_group_by_id(
+            session, der_program_id, include_default=True, site_id=site.site_id
+        )
         if not site_control_group:
             raise NotFoundError(f"der_program_id {der_program_id} is not accessible / does not exist")
 

--- a/src/envoy/server/manager/end_device.py
+++ b/src/envoy/server/manager/end_device.py
@@ -26,6 +26,7 @@ from envoy.server.crud.site import (
     select_single_site_with_sfdi,
     select_single_site_with_site_id,
 )
+from envoy.server.crud.site_group import assign_default_site_groups_to_site
 from envoy.server.crud.subscription import count_subscriptions_for_site
 from envoy.server.exception import (
     BadRequestError,
@@ -228,6 +229,8 @@ class EndDeviceManager:
                 f"EndDevice with provided sFDI ({site.sfdi}) or lFDI ({site.lfdi})"
                 f"already exists for aggregator ({site.aggregator_id})."
             ) from exc
+
+        await assign_default_site_groups_to_site(session, result, changed_time)
 
         await NotificationManager.notify_changed_deleted_entities(session, SubscriptionResource.SITE, changed_time)
         await session.commit()

--- a/src/envoy/server/manager/pricing.py
+++ b/src/envoy/server/manager/pricing.py
@@ -45,7 +45,7 @@ class TariffProfileManager:
     ) -> TariffProfileResponse | None:
         """Fetches a single tariff in the form of a sep2 TariffProfile thats specific to a single site."""
 
-        tariff = await select_single_tariff(session, tariff_id)
+        tariff = await select_single_tariff(session, tariff_id, site_id=scope.site_id)
         if tariff is None:
             return None
 
@@ -66,8 +66,8 @@ class TariffProfileManager:
         """Fetches all tariffs accessible to a specific site (and optionally scoped to a specific function set
         assignment id)."""
 
-        tariffs = await select_all_tariffs(session, start, changed_after, limit, fsa_id)
-        tariff_count = await select_tariff_count(session, changed_after, fsa_id)
+        tariffs = await select_all_tariffs(session, start, changed_after, limit, fsa_id, site_id=scope.site_id)
+        tariff_count = await select_tariff_count(session, changed_after, fsa_id, site_id=scope.site_id)
 
         # we need the rate counts associated with each Tariff+Site. Those are derived from dates with a Rate
         tariff_rate_counts: list[int] = []

--- a/src/envoy/server/model/archive/doe.py
+++ b/src/envoy/server/model/archive/doe.py
@@ -25,6 +25,7 @@ class ArchiveSiteControlGroup(ArchiveBase):
     changed_time: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 
     display_id: Mapped[int | None] = mapped_column(nullable=True)
+    required_site_group_id: Mapped[int | None] = mapped_column(INTEGER, nullable=True)
 
 
 class ArchiveSiteControlGroupDefault(ArchiveBase):

--- a/src/envoy/server/model/archive/tariff.py
+++ b/src/envoy/server/model/archive/tariff.py
@@ -16,6 +16,7 @@ class ArchiveTariff(ArchiveBase):
     dnsp_code: Mapped[str] = mapped_column(String(20))
     currency_code: Mapped[CurrencyCode] = mapped_column(Integer)
     fsa_id: Mapped[int] = mapped_column(Integer)
+    required_site_group_id: Mapped[int | None] = mapped_column(INTEGER, nullable=True)
     created_time: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     changed_time: Mapped[datetime] = mapped_column(DateTime(timezone=True))
 

--- a/src/envoy/server/model/doe.py
+++ b/src/envoy/server/model/doe.py
@@ -35,6 +35,10 @@ class SiteControlGroup(Base):
         index=True, nullable=True
     )  # If set - use this for MRID calculation instead of site_control_group_id
 
+    required_site_group_id: Mapped[int | None] = mapped_column(
+        ForeignKey("site_group.site_group_id"), nullable=True, index=True
+    )  # If set - only sites that are members of this SiteGroup will "see" this SiteControlGroup. Otherwise global
+
     dynamic_operating_envelopes: Mapped[list["DynamicOperatingEnvelope"]] = relationship(
         lazy="raise", back_populates="site_control_group"
     )

--- a/src/envoy/server/model/site.py
+++ b/src/envoy/server/model/site.py
@@ -18,6 +18,7 @@ from envoy_schema.server.schema.sep2.der import (
 from envoy_schema.server.schema.sep2.log_events import FunctionSetIdentifier, ProfileIdentifier
 from envoy_schema.server.schema.sep2.types import DeviceCategory
 from sqlalchemy import (
+    BOOLEAN,
     DECIMAL,
     INTEGER,
     SMALLINT,
@@ -103,6 +104,9 @@ class SiteGroup(Base):
         DateTime(timezone=True), server_default=func.now()
     )  # When the site group was created
     changed_time: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    default_group: Mapped[bool] = mapped_column(
+        BOOLEAN, nullable=False, default=False, server_default="false", index=True
+    )  # If set - all new site registrations (in/out of band) will be automatically assigned to this group
 
     assignments: Mapped[list["SiteGroupAssignment"]] = relationship(
         back_populates="group",

--- a/src/envoy/server/model/tariff.py
+++ b/src/envoy/server/model/tariff.py
@@ -23,6 +23,9 @@ class Tariff(Base):
     fsa_id: Mapped[int] = mapped_column(
         Integer, index=True, server_default="1"
     )  # Function set assignment ID that will group this Tariff with other Tariffs
+    required_site_group_id: Mapped[int | None] = mapped_column(
+        ForeignKey("site_group.site_group_id"), nullable=True, index=True
+    )  # If set - only sites that are members of this SiteGroup will "see" this Tariff. Otherwise globally visible
     created_time: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )  # When the tariff was created

--- a/tests/integration/admin/test_pricing.py
+++ b/tests/integration/admin/test_pricing.py
@@ -36,7 +36,7 @@ async def test_get_single_tariff(admin_client_auth: AsyncClient):
 
 @pytest.mark.anyio
 async def test_create_tariff(admin_client_auth: AsyncClient):
-    tariff = generate_class_instance(TariffRequest)
+    tariff = generate_class_instance(TariffRequest, required_site_group_id=None)
     tariff.currency_code = CurrencyCode.AUSTRALIAN_DOLLAR
     resp = await admin_client_auth.post(TariffCreateUri, json=tariff.model_dump())
 
@@ -45,7 +45,7 @@ async def test_create_tariff(admin_client_auth: AsyncClient):
 
 @pytest.mark.anyio
 async def test_update_tariff(admin_client_auth: AsyncClient):
-    tariff = generate_class_instance(TariffRequest)
+    tariff = generate_class_instance(TariffRequest, required_site_group_id=None)
     tariff.currency_code = CurrencyCode.AUSTRALIAN_DOLLAR
     resp = await admin_client_auth.put(TariffUpdateUri.format(tariff_id=1), json=tariff.model_dump())
 

--- a/tests/integration/admin/test_site.py
+++ b/tests/integration/admin/test_site.py
@@ -226,6 +226,7 @@ async def test_get_all_site_groups(
         assert group_page.start == start
 
     assert [(g.site_group_id, g.total_sites) for g in group_page.groups] == expected_group_count
+    assert all(g.default_group is False for g in group_page.groups), "No groups are marked default in base_config"
 
 
 @pytest.mark.parametrize(
@@ -259,6 +260,7 @@ async def test_get_site_groups(
         assert group.site_group_id == expected_group_count[0]
         assert group.total_sites == expected_group_count[1]
         assert group.name == group_name
+        assert group.default_group is False, "No groups are marked default in base_config"
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/admin/test_site_control.py
+++ b/tests/integration/admin/test_site_control.py
@@ -38,7 +38,7 @@ from tests.integration.response import read_location_header, read_response_body_
 @pytest.mark.anyio
 async def test_create_site_control_group(admin_client_auth: AsyncClient):
     """Tests that site control groups can be created and then fetched"""
-    group_request = generate_class_instance(SiteControlGroupRequest)
+    group_request = generate_class_instance(SiteControlGroupRequest, required_site_group_id=None)
     resp = await admin_client_auth.post(SiteControlGroupListUri, content=group_request.model_dump_json())
 
     assert resp.status_code == HTTPStatus.CREATED
@@ -69,7 +69,9 @@ async def test_update_site_control_group_change(pg_base_config, admin_client_aut
 
     site_control_group_id = 1
     uri = SiteControlGroupUri.format(group_id=site_control_group_id)
-    group_request = generate_class_instance(SiteControlGroupRequest, fsa_id=fsa_id, display_id=None)
+    group_request = generate_class_instance(
+        SiteControlGroupRequest, fsa_id=fsa_id, display_id=None, required_site_group_id=None
+    )
     resp = await admin_client_auth.put(uri, content=group_request.model_dump_json())
 
     assert resp.status_code == HTTPStatus.OK

--- a/tests/integration/func_sets/test_derp.py
+++ b/tests/integration/func_sets/test_derp.py
@@ -20,7 +20,7 @@ from envoy_schema.server.schema.sep2.der import (
 )
 from freezegun import freeze_time
 from httpx import AsyncClient
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from envoy.server.crud.site import VIRTUAL_END_DEVICE_SITE_ID
 from envoy.server.manager.time import utc_now
@@ -144,6 +144,67 @@ async def test_get_derprogram_list(
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
+    "start, limit, after, site_id, expected_derp_ids_with_count, expected_status",
+    [
+        (None, 99, None, 1, [(1, 3), (2, 0), (3, 0)], HTTPStatus.OK),  # Site 1 is a member of group 1/2
+        (None, 99, None, 2, [(2, 0)], HTTPStatus.OK),  # Site 2 is a member of group 1
+        (None, 99, None, 4, [], HTTPStatus.OK),  # Site 4 is NOT a member of any group
+        (0, 2, None, 1, [(1, 3), (2, 0)], HTTPStatus.OK),  # Site 1 is a member of group 1/2
+        (1, 2, None, 1, [(2, 0), (3, 0)], HTTPStatus.OK),  # Site 1 is a member of group 1/2
+    ],
+)
+@freeze_time("2010-01-01")  # This endpoint is sensitive to "now" and won't report on "old" DOEs
+async def test_get_derprogram_list_required_site_group_id(
+    client: AsyncClient,
+    pg_base_config,
+    uri_derp_list_format,
+    start: int | None,
+    limit: int | None,
+    after: datetime | None,
+    site_id: int,
+    expected_derp_ids_with_count: list[tuple[int, int]] | None,
+    expected_status: HTTPStatus,
+    agg_1_headers,
+):
+    """Tests getting DERPrograms filters on required_site_group_id"""
+
+    # Arrange - setup every SiteControl group to be restricted to Group #1 / #2 membership
+    async with generate_async_session(pg_base_config) as session:
+        await session.execute(
+            update(SiteControlGroup)
+            .values(required_site_group_id=2)
+            .where(SiteControlGroup.site_control_group_id.in_([1, 3]))
+        )
+        await session.execute(
+            update(SiteControlGroup)
+            .values(required_site_group_id=1)
+            .where(SiteControlGroup.site_control_group_id.in_([2]))
+        )
+        await session.commit()
+
+    path = uri_derp_list_format.format(site_id=site_id) + build_paging_params(start, limit, after)
+    response = await client.get(path, headers=agg_1_headers)
+
+    assert_response_header(response, expected_status)
+    if expected_derp_ids_with_count is None:
+        assert_error_response(response)
+    else:
+        body = read_response_body_string(response)
+        assert len(body) > 0
+        parsed_response: DERProgramListResponse = DERProgramListResponse.from_xml(body)
+        assert parsed_response.href == uri_derp_list_format.format(site_id=site_id)
+        assert parsed_response.results == len(expected_derp_ids_with_count)
+        assert len(parsed_response.DERProgram or []) == len(expected_derp_ids_with_count)
+
+        actual_derp_ids_with_count = [
+            (int(derp.href.split("/")[-1]), derp.DERControlListLink.all_)  # ty:ignore[unresolved-attribute]
+            for derp in parsed_response.DERProgram or []
+        ]
+        assert expected_derp_ids_with_count == actual_derp_ids_with_count
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
     "start, limit, after, site_id, fsa_id, expected_derp_ids_with_count, expected_status",
     [
         (None, 99, None, 1, 1, [(1, 3), (2, 0), (3, 0)], HTTPStatus.OK),
@@ -183,6 +244,7 @@ async def test_get_derprogram_list_fsa_scoped(
                 seed=303,
                 site_control_group_id=4,
                 fsa_id=3,
+                required_site_group_id=None,
                 changed_time=datetime(2021, 4, 5, 10, 4, 0, tzinfo=UTC),
             )
         )

--- a/tests/integration/func_sets/test_end_device.py
+++ b/tests/integration/func_sets/test_end_device.py
@@ -15,10 +15,11 @@ from envoy_schema.server.schema.sep2.end_device import (
 )
 from envoy_schema.server.schema.sep2.types import DeviceCategory
 from httpx import AsyncClient
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 
 from envoy.admin.crud.site import count_all_sites
 from envoy.server.model.archive.site import ArchiveSite
+from envoy.server.model.site import Site, SiteGroup, SiteGroupAssignment
 from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as AGG_1_VALID_CERT
 from tests.data.certificates.certificate1 import TEST_CERTIFICATE_LFDI as AGG_1_LFDI_FROM_VALID_CERT
 from tests.data.certificates.certificate1 import TEST_CERTIFICATE_SFDI as AGG_1_SFDI_FROM_VALID_CERT
@@ -372,6 +373,47 @@ async def test_create_end_device_specified_sfdi(client: AsyncClient, edev_base_u
     assert len(body) > 0
     parsed_response: EndDeviceListResponse = EndDeviceListResponse.from_xml(body)
     assert parsed_response.all_ == 5, f"received body:\n{body}"
+
+
+@pytest.mark.anyio
+async def test_create_end_device_assigns_default_site_groups(
+    pg_base_config, client: AsyncClient, edev_base_uri: str
+) -> None:
+    """A newly registered EndDevice should automatically become a member of every SiteGroup marked default_group -
+    and should NOT be added to groups that aren't marked default"""
+
+    # Group-3 currently has no members - mark it (and only it) as a "default" group
+    async with generate_async_session(pg_base_config) as session:
+        await session.execute(update(SiteGroup).where(SiteGroup.name == "Group-3").values(default_group=True))
+        await session.commit()
+
+    insert_request: EndDeviceRequest = generate_class_instance(
+        EndDeviceRequest, postRate=123, deviceCategory=f"{int(DeviceCategory.HOT_TUB):x}", lFDI="fedcba9876543210"
+    )
+    response = await client.post(
+        edev_base_uri,
+        headers={cert_header: urllib.parse.quote(AGG_1_VALID_CERT)},
+        content=EndDeviceRequest.to_xml(insert_request),
+    )
+    assert_response_header(response, HTTPStatus.CREATED, expected_content_type=None)
+
+    async with generate_async_session(pg_base_config) as session:
+        inserted_site_id = (
+            await session.execute(select(Site.site_id).where(Site.lfdi == insert_request.lFDI))
+        ).scalar_one()
+
+        member_group_names = (
+            (
+                await session.execute(
+                    select(SiteGroup.name)
+                    .join(SiteGroupAssignment, SiteGroupAssignment.site_group_id == SiteGroup.site_group_id)
+                    .where(SiteGroupAssignment.site_id == inserted_site_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert set(member_group_names) == {"Group-3"}, "Only the default group should've picked up the new site"
 
 
 @pytest.mark.anyio

--- a/tests/integration/func_sets/test_pricing.py
+++ b/tests/integration/func_sets/test_pricing.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from http import HTTPStatus
 
 import pytest
+from assertical.fixtures.postgres import generate_async_session
 from envoy_schema.server.schema import uri
 from envoy_schema.server.schema.sep2.metering import ReadingType
 from envoy_schema.server.schema.sep2.pricing import (
@@ -16,8 +17,10 @@ from envoy_schema.server.schema.sep2.pricing import (
     TimeTariffIntervalResponse,
 )
 from httpx import AsyncClient
+from sqlalchemy import update
 
 from envoy.server.mapper.constants import PricingReadingType
+from envoy.server.model import Tariff
 from envoy.server.model.tariff import PRICE_DECIMAL_PLACES
 from tests.data.certificates.certificate1 import TEST_CERTIFICATE_FINGERPRINT as AGG_1_VALID_CERT
 from tests.integration.integration_server import cert_header
@@ -101,6 +104,63 @@ async def test_get_tariffprofilelist(
     expected_tariffs_with_count: list[tuple[str, int]],
 ):
     """Tests that the list pagination works correctly on the site scoped tariff profile list"""
+    path = uri.TariffProfileListUri.format(site_id=site_id) + build_paging_params(start, limit, changed_after)
+    response = await client.get(path, headers=agg_1_headers)
+    assert_response_header(response, HTTPStatus.OK)
+    body = read_response_body_string(response)
+    assert len(body) > 0
+
+    parsed_response: TariffProfileListResponse = TariffProfileListResponse.from_xml(body)
+    assert parsed_response
+    assert parsed_response.href == uri.TariffProfileListUri.format(site_id=site_id)
+    assert parsed_response.results == len(expected_tariffs_with_count)
+    assert len(parsed_response.TariffProfile or []) == len(expected_tariffs_with_count)
+
+    # Check that the rate counts and referenced rate component counts match our expectations
+    expected_tariffs = [href for (href, _) in expected_tariffs_with_count]
+    expected_rate_counts = [rate_count for (_, rate_count) in expected_tariffs_with_count]
+    assert expected_tariffs == [tp.href for tp in parsed_response.TariffProfile or []]
+    assert expected_rate_counts == [
+        tp.RateComponentListLink.all_
+        for tp in parsed_response.TariffProfile or []
+        if tp.RateComponentListLink is not None
+    ]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "site_id, start, limit, changed_after, expected_tariffs_with_count",
+    [
+        (
+            1,
+            0,
+            99,
+            None,
+            [("/edev/1/tp/3", 0), ("/edev/1/tp/2", 0), ("/edev/1/tp/1", 8)],
+        ),  # Site 1 is a member of group 1/2
+        (2, 0, 99, None, [("/edev/2/tp/2", 0)]),  # Site 2 is a member of group 1
+        (4, 0, 99, None, []),  # Site 4 has no group
+        (1, 2, 99, None, [("/edev/1/tp/1", 8)]),  # Site 1 is a member of group 1/2
+        (1, 1, 1, None, [("/edev/1/tp/2", 0)]),  # Site 1 is a member of group 1/2
+    ],
+)
+async def test_get_tariffprofilelist_required_site_group_id(
+    pg_base_config,
+    client: AsyncClient,
+    agg_1_headers,
+    site_id: int,
+    start: int | None,
+    limit: int | None,
+    changed_after: datetime | None,
+    expected_tariffs_with_count: list[tuple[str, int]],
+):
+    """Tests getting TariffProfile filters on required_site_group_id"""
+
+    # Arrange - setup every Tariff to be restricted to Group #1 / #2 membership
+    async with generate_async_session(pg_base_config) as session:
+        await session.execute(update(Tariff).values(required_site_group_id=2).where(Tariff.tariff_id.in_([1, 3])))
+        await session.execute(update(Tariff).values(required_site_group_id=1).where(Tariff.tariff_id.in_([2])))
+        await session.commit()
     path = uri.TariffProfileListUri.format(site_id=site_id) + build_paging_params(start, limit, changed_after)
     response = await client.get(path, headers=agg_1_headers)
     assert_response_header(response, HTTPStatus.OK)

--- a/tests/unit/admin/crud/test_doe.py
+++ b/tests/unit/admin/crud/test_doe.py
@@ -429,6 +429,7 @@ async def extra_site_control_groups(pg_base_config):
                 seed=303,
                 primacy=1,
                 site_control_group_id=4,
+                required_site_group_id=None,
                 changed_time=datetime(2021, 4, 5, 10, 4, 0, 500000, tzinfo=UTC),
             )
         )

--- a/tests/unit/admin/crud/test_pricing.py
+++ b/tests/unit/admin/crud/test_pricing.py
@@ -23,7 +23,7 @@ async def _select_latest_tariff_generated_rate(session) -> TariffGeneratedRate:
 @pytest.mark.anyio
 async def test_insert_single_tariff(pg_empty_config):
     async with generate_async_session(pg_empty_config) as session:
-        tariff_in = generate_class_instance(Tariff, tariff_id=None)
+        tariff_in = generate_class_instance(Tariff, tariff_id=None, required_site_group_id=None)
         await insert_single_tariff(session, tariff_in)
 
         await session.flush()
@@ -43,7 +43,7 @@ async def test_insert_single_tariff(pg_empty_config):
 @pytest.mark.anyio
 async def test_update_single_tariff(pg_base_config):
     async with generate_async_session(pg_base_config) as session:
-        tariff_in = generate_class_instance(Tariff)
+        tariff_in = generate_class_instance(Tariff, required_site_group_id=None)
         tariff_in.tariff_id = 1
         await update_single_tariff(session, tariff_in)
         await session.flush()

--- a/tests/unit/admin/mapper/test_pricing.py
+++ b/tests/unit/admin/mapper/test_pricing.py
@@ -22,7 +22,9 @@ def test_tariff_mapper_roundtrip(optional_is_none: bool):
     mdl.created_time = created_time
     actual = TariffMapper.map_to_response(mdl)
 
-    assert_class_instance_equality(TariffRequest, expected, actual)
+    # required_site_group_id has no equivalent field on TariffResponse (envoy-schema doesn't carry it through to
+    # the response side) so it can't round-trip - it's still exercised separately in test_tariff_mapper_from_request
+    assert_class_instance_equality(TariffRequest, expected, actual, ignored_properties={"required_site_group_id"})
     assert actual.changed_time == changed_time
     assert actual.created_time == created_time
     assert actual.tariff_id == 123321
@@ -36,6 +38,7 @@ def test_tariff_mapper_from_request():
     assert isinstance(mdl, Tariff)
     assert mdl.changed_time == changed_time
     assert mdl.tariff_id == None  # noqa
+    assert mdl.required_site_group_id == req.required_site_group_id
 
 
 def test_tariff_mapper_to_response():

--- a/tests/unit/notification/crud/test_batch.py
+++ b/tests/unit/notification/crud/test_batch.py
@@ -11,7 +11,7 @@ from assertical.fake.generator import generate_class_instance
 from assertical.fixtures.postgres import generate_async_session
 from envoy_schema.server.schema.sep2.pub_sub import ConditionAttributeIdentifier
 from envoy_schema.server.schema.sep2.types import QualityFlagsType
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from envoy.notification.crud.batch import (
     AggregatorBatchedEntities,
@@ -64,7 +64,7 @@ from envoy.server.model.archive.site import (
 from envoy.server.model.archive.site_reading import ArchiveSiteReading, ArchiveSiteReadingType
 from envoy.server.model.archive.tariff import ArchiveTariffGeneratedRate
 from envoy.server.model.base import Base
-from envoy.server.model.doe import DynamicOperatingEnvelope, SiteControlGroupDefault
+from envoy.server.model.doe import DynamicOperatingEnvelope, SiteControlGroup, SiteControlGroupDefault
 from envoy.server.model.site import (
     SiteDERAvailability,
     SiteDERRating,
@@ -75,7 +75,7 @@ from envoy.server.model.site import (
 )
 from envoy.server.model.site_reading import SiteReading, SiteReadingType
 from envoy.server.model.subscription import Subscription, SubscriptionCondition, SubscriptionResource
-from envoy.server.model.tariff import TariffGeneratedRate
+from envoy.server.model.tariff import Tariff, TariffGeneratedRate
 
 
 def assert_batched_entities(
@@ -877,6 +877,54 @@ async def test_fetch_rates_by_timestamp_with_archive(pg_base_config):
         )
         assert len(empty_batch.models_by_batch_key) == 0
         assert len(empty_batch.deleted_by_batch_key) == 0
+
+
+@pytest.mark.anyio
+async def test_fetch_rates_by_timestamp_required_site_group_id(pg_base_config):
+    """A rate's parent Tariff can restrict visibility via required_site_group_id - this should be intersected
+    with the rate's own site_group_id membership when fanning out.
+
+    tariff_generated_rate 1 (tariff_id 1) targets site_group_id 2 (site1's singleton group). If tariff 1's
+    required_site_group_id is set to group 4 (site2's singleton) then site1 is no longer a permitted recipient
+    (it isn't a member of group 4) so the rate should be fanned out to nobody."""
+
+    timestamp = datetime(2022, 3, 4, 11, 22, 33, 500000, tzinfo=UTC)
+
+    async with generate_async_session(pg_base_config) as session:
+        await session.execute(update(Tariff).where(Tariff.tariff_id == 1).values(required_site_group_id=4))
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        batch = await fetch_rates_by_changed_at(session, timestamp)
+        assert_batched_entities(
+            batch,
+            SiteScopedTariffGeneratedRate,  # ty:ignore[invalid-argument-type]
+            ArchiveSiteScopedTariffGeneratedRate,  # ty:ignore[invalid-argument-type]
+            0,
+            0,
+        )
+        assert len(batch.models_by_batch_key) == 0
+
+
+@pytest.mark.anyio
+async def test_fetch_rates_by_timestamp_required_site_group_id_allows_member(pg_base_config):
+    """As test_fetch_rates_by_timestamp_required_site_group_id but the required_site_group_id is set to a group
+    that DOES include the rate's member site, so the rate should still be fanned out as normal."""
+
+    timestamp = datetime(2022, 3, 4, 11, 22, 33, 500000, tzinfo=UTC)
+
+    async with generate_async_session(pg_base_config) as session:
+        # site_group 2 is site1's own singleton - rate 1 (site_group_id 2) is already restricted to site1, so this
+        # is a no-op restriction
+        await session.execute(update(Tariff).where(Tariff.tariff_id == 1).values(required_site_group_id=2))
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        batch = await fetch_rates_by_changed_at(session, timestamp)
+        list_entities = [e for _, entities in batch.models_by_batch_key.items() for e in entities]
+        assert len(list_entities) == 1
+        assert list_entities[0].site_id == 1
+        assert list_entities[0].aggregator_id == 1
 
 
 @pytest.mark.parametrize(
@@ -2336,6 +2384,42 @@ async def test_fetch_site_control_groups_by_changed_at(
 
 
 @pytest.mark.anyio
+async def test_fetch_site_control_groups_by_changed_at_required_site_group_id(pg_base_config):
+    """A SiteControlGroup with required_site_group_id set should only fan out to member sites of that group -
+    site2's singleton group (id 4) only has site2 as a member"""
+
+    timestamp = datetime(2024, 6, 7, 8, 9, 10, 500000, tzinfo=UTC)
+
+    async with generate_async_session(pg_base_config) as session:
+        session.add(
+            generate_class_instance(
+                SiteControlGroup,
+                seed=606,
+                site_control_group_id=6,
+                fsa_id=None,
+                display_id=None,
+                required_site_group_id=4,  # Group-4-Site2's singleton - only site2 is a member
+                changed_time=timestamp,
+            )
+        )
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        batch = await fetch_site_control_groups_by_changed_at(session, timestamp)
+        assert_batched_entities(
+            batch,
+            SiteScopedSiteControlGroup,  # ty:ignore[invalid-argument-type]
+            ArchiveSiteScopedSiteControlGroup,  # ty:ignore[invalid-argument-type]
+            1,
+            0,
+        )
+        list_entities = [e for _, entities in batch.models_by_batch_key.items() for e in entities]
+        assert len(list_entities) == 1
+        assert list_entities[0].site_id == 2, "Only site2 is a member of the required SiteGroup"
+        assert list_entities[0].aggregator_id == 1
+
+
+@pytest.mark.anyio
 async def test_fetch_site_control_groups_by_timestamp_with_archive(pg_base_config):
     """Tests that entities are filtered/returned correctly and include archive data"""
 
@@ -2353,6 +2437,7 @@ async def test_fetch_site_control_groups_by_timestamp_with_archive(pg_base_confi
                 ArchiveSiteControlGroup,
                 seed=55,
                 site_control_group_id=21,
+                required_site_group_id=None,
             )
         )
         session.add(
@@ -2361,6 +2446,7 @@ async def test_fetch_site_control_groups_by_timestamp_with_archive(pg_base_confi
                 seed=66,
                 site_control_group_id=21,
                 deleted_time=timestamp - timedelta(seconds=5),
+                required_site_group_id=None,
             )
         )
         session.add(
@@ -2370,11 +2456,16 @@ async def test_fetch_site_control_groups_by_timestamp_with_archive(pg_base_confi
                 site_control_group_id=21,
                 deleted_time=timestamp,
                 primacy=21,  # for identifying this record later
+                required_site_group_id=None,
             )
         )
 
         # No deleted time so ignored
-        session.add(generate_class_instance(ArchiveSiteControlGroup, seed=88, site_control_group_id=22))
+        session.add(
+            generate_class_instance(
+                ArchiveSiteControlGroup, seed=88, site_control_group_id=22, required_site_group_id=None
+            )
+        )
 
         # Wrong deleted time so ignored
         session.add(
@@ -2383,6 +2474,7 @@ async def test_fetch_site_control_groups_by_timestamp_with_archive(pg_base_confi
                 seed=99,
                 site_control_group_id=23,
                 deleted_time=timestamp - timedelta(seconds=5),
+                required_site_group_id=None,
             )
         )
 
@@ -2394,6 +2486,7 @@ async def test_fetch_site_control_groups_by_timestamp_with_archive(pg_base_confi
                 site_control_group_id=24,
                 deleted_time=timestamp,
                 primacy=24,  # for identifying this record later
+                required_site_group_id=None,
             )
         )
         session.add(
@@ -2403,6 +2496,7 @@ async def test_fetch_site_control_groups_by_timestamp_with_archive(pg_base_confi
                 site_control_group_id=25,
                 deleted_time=timestamp,
                 primacy=25,  # for identifying this record later
+                required_site_group_id=None,
             )
         )
         await session.commit()

--- a/tests/unit/server/crud/test_doe.py
+++ b/tests/unit/server/crud/test_doe.py
@@ -674,6 +674,7 @@ async def extra_site_control_groups(pg_base_config):
                 primacy=1,
                 site_control_group_id=4,
                 fsa_id=3,
+                required_site_group_id=None,
                 changed_time=datetime(2021, 4, 5, 10, 4, 0, 500000, tzinfo=UTC),
             )
         )
@@ -684,6 +685,7 @@ async def extra_site_control_groups(pg_base_config):
                 primacy=1,
                 site_control_group_id=5,
                 fsa_id=None,
+                required_site_group_id=None,
                 changed_time=datetime(2021, 4, 5, 10, 4, 0, 500000, tzinfo=UTC),
             )
         )
@@ -862,3 +864,73 @@ async def test_select_site_control_group_fsa_ids(
         actual_ids = await select_site_control_group_fsa_ids(session, changed_after)
         assert_list_type(int, actual_ids, len(expected_fsa_ids))
         assert set(expected_fsa_ids) == set(actual_ids)
+
+
+@pytest.fixture
+async def site_control_group_with_required_site_group(pg_base_config):
+    """Adds a SiteControlGroup (id 6) whose required_site_group_id is set to site2's singleton group (id 4) -
+    only site2 should be able to "see" this group"""
+    async with generate_async_session(pg_base_config) as session:
+        session.add(
+            generate_class_instance(
+                SiteControlGroup,
+                seed=606,
+                site_control_group_id=6,
+                primacy=99,
+                fsa_id=None,
+                display_id=None,
+                required_site_group_id=SITE_ID_TO_SINGLETON_GROUP_ID[2],
+                changed_time=datetime(2021, 4, 5, 10, 6, 0, 500000, tzinfo=UTC),
+            )
+        )
+        await session.commit()
+    yield pg_base_config
+
+
+@pytest.mark.parametrize(
+    "site_id, expected_visible",
+    [
+        (None, True),  # No site scope (eg admin) - always visible
+        (2, True),  # site2 is a member of the required SiteGroup
+        (1, False),  # site1 is not a member of the required SiteGroup
+        (3, False),  # site3 is not a member of the required SiteGroup
+        (99, False),  # site doesn't even exist
+    ],
+)
+@pytest.mark.anyio
+async def test_select_site_control_group_by_id_required_site_group_id_filtering(
+    site_control_group_with_required_site_group, site_id: int | None, expected_visible: bool
+):
+    async with generate_async_session(site_control_group_with_required_site_group) as session:
+        result = await select_site_control_group_by_id(session, 6, site_id=site_id)
+        if expected_visible:
+            assert result is not None
+            assert result.site_control_group_id == 6
+        else:
+            assert result is None
+
+
+@pytest.mark.parametrize(
+    "site_id, expect_included",
+    [
+        (None, True),
+        (2, True),
+        (1, False),
+        (3, False),
+    ],
+)
+@pytest.mark.anyio
+async def test_select_and_count_site_control_groups_required_site_group_id_filtering(
+    site_control_group_with_required_site_group, site_id: int | None, expect_included: bool
+):
+    async with generate_async_session(site_control_group_with_required_site_group) as session:
+        groups = await select_site_control_groups(session, 0, datetime.min, 99, None, site_id=site_id)
+        group_ids = [g.site_control_group_id for g in groups]
+        count = await count_site_control_groups(session, datetime.min, None, site_id=site_id)
+
+        if expect_included:
+            assert 6 in group_ids
+        else:
+            assert 6 not in group_ids
+
+        assert count == len(groups), "Count and list results should agree on visibility filtering"

--- a/tests/unit/server/crud/test_pricing.py
+++ b/tests/unit/server/crud/test_pricing.py
@@ -5,6 +5,7 @@ from zoneinfo import ZoneInfo
 import pytest
 from assertical.asserts.time import assert_datetime_equal
 from assertical.asserts.type import assert_list_type
+from assertical.fake.generator import generate_class_instance
 from assertical.fixtures.postgres import generate_async_session
 
 from envoy.server.crud.pricing import (
@@ -463,3 +464,71 @@ async def test_select_tariff_generated_rate_for_scope_la_timezone(
             expected_tz="America/Los_Angeles",
             actual_rate=actual,
         )
+
+
+@pytest.fixture
+async def tariff_with_required_site_group(pg_base_config):
+    """Adds a Tariff (id 4) whose required_site_group_id is set to site2's singleton group (id 4) - only site2
+    should be able to "see" this Tariff"""
+    async with generate_async_session(pg_base_config) as session:
+        session.add(
+            generate_class_instance(
+                Tariff,
+                seed=404,
+                tariff_id=4,
+                fsa_id=None,
+                required_site_group_id=SITE_ID_TO_SINGLETON_GROUP_ID[2],
+                changed_time=datetime(2023, 1, 2, 14, 1, 2, tzinfo=UTC),
+            )
+        )
+        await session.commit()
+    yield pg_base_config
+
+
+@pytest.mark.parametrize(
+    "site_id, expected_visible",
+    [
+        (None, True),  # No site scope (eg admin) - always visible
+        (2, True),  # site2 is a member of the required SiteGroup
+        (1, False),  # site1 is not a member of the required SiteGroup
+        (3, False),  # site3 is not a member of the required SiteGroup
+        (99, False),  # site doesn't even exist
+    ],
+)
+@pytest.mark.anyio
+async def test_select_single_tariff_required_site_group_id_filtering(
+    tariff_with_required_site_group, site_id: int | None, expected_visible: bool
+):
+    async with generate_async_session(tariff_with_required_site_group) as session:
+        result = await select_single_tariff(session, 4, site_id=site_id)
+        if expected_visible:
+            assert result is not None
+            assert result.tariff_id == 4
+        else:
+            assert result is None
+
+
+@pytest.mark.parametrize(
+    "site_id, expect_included",
+    [
+        (None, True),
+        (2, True),
+        (1, False),
+        (3, False),
+    ],
+)
+@pytest.mark.anyio
+async def test_select_all_tariffs_and_count_required_site_group_id_filtering(
+    tariff_with_required_site_group, site_id: int | None, expect_included: bool
+):
+    async with generate_async_session(tariff_with_required_site_group) as session:
+        tariffs = await select_all_tariffs(session, 0, datetime.min, 99, None, site_id=site_id)
+        tariff_ids = [t.tariff_id for t in tariffs]
+        count = await select_tariff_count(session, datetime.min, None, site_id=site_id)
+
+        if expect_included:
+            assert 4 in tariff_ids
+        else:
+            assert 4 not in tariff_ids
+
+        assert count == len(tariffs), "Count and list results should agree on visibility filtering"

--- a/tests/unit/server/crud/test_site_group.py
+++ b/tests/unit/server/crud/test_site_group.py
@@ -1,0 +1,66 @@
+from datetime import UTC, datetime
+
+import pytest
+from assertical.fixtures.postgres import generate_async_session
+from sqlalchemy import select, update
+
+from envoy.server.crud.site_group import assign_default_site_groups_to_site
+from envoy.server.model.site import SiteGroup, SiteGroupAssignment
+
+CHANGED_TIME = datetime(2024, 11, 1, 2, 3, 4, tzinfo=UTC)
+
+
+@pytest.mark.anyio
+async def test_assign_default_site_groups_to_site_no_defaults(pg_base_config):
+    """If no SiteGroup is marked default_group - assigning a new site shouldn't create any assignments"""
+
+    async with generate_async_session(pg_base_config) as session:
+        before = (await session.execute(select(SiteGroupAssignment.site_group_assignment_id))).scalars().all()
+
+        await assign_default_site_groups_to_site(session, 4, CHANGED_TIME)
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        after = (await session.execute(select(SiteGroupAssignment.site_group_assignment_id))).scalars().all()
+        assert len(after) == len(before), "No default groups exist - no assignments should be created"
+
+
+@pytest.mark.anyio
+async def test_assign_default_site_groups_to_site_with_defaults(pg_base_config):
+    """SiteGroups marked default_group=True should all pick up a new site as a member. Groups that aren't marked
+    default should be left untouched."""
+
+    async with generate_async_session(pg_base_config) as session:
+        # Group 3 and 4 become "default" groups - group 1/2/5 remain untouched
+        await session.execute(update(SiteGroup).where(SiteGroup.site_group_id.in_([3, 4])).values(default_group=True))
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        # Site 4 isn't currently a member of any group (see base_config.sql)
+        await assign_default_site_groups_to_site(session, 4, CHANGED_TIME)
+        await session.commit()
+
+    async with generate_async_session(pg_base_config) as session:
+        site_4_group_ids = set(
+            (await session.execute(select(SiteGroupAssignment.site_group_id).where(SiteGroupAssignment.site_id == 4)))
+            .scalars()
+            .all()
+        )
+        assert site_4_group_ids == {3, 4}
+
+        new_assignment = (
+            await session.execute(
+                select(SiteGroupAssignment).where(
+                    (SiteGroupAssignment.site_id == 4) & (SiteGroupAssignment.site_group_id == 3)
+                )
+            )
+        ).scalar_one()
+        assert new_assignment.changed_time == CHANGED_TIME
+
+        # Group 1 (not marked default) should be untouched - site 4 shouldn't have joined it
+        group_1_site_ids = set(
+            (await session.execute(select(SiteGroupAssignment.site_id).where(SiteGroupAssignment.site_group_id == 1)))
+            .scalars()
+            .all()
+        )
+        assert group_1_site_ids == {1, 2, 3}

--- a/tests/unit/server/manager/test_derp.py
+++ b/tests/unit/server/manager/test_derp.py
@@ -76,7 +76,13 @@ async def test_program_fetch_list_for_scope(
 
     mock_select_single_site_with_site_id.assert_called_once_with(mock_session, scope.site_id, scope.aggregator_id)
     mock_select_site_control_groups.assert_called_once_with(
-        mock_session, start=start, limit=limit, changed_after=changed_after, fsa_id=fsa_id, include_defaults=True
+        mock_session,
+        start=start,
+        limit=limit,
+        changed_after=changed_after,
+        fsa_id=fsa_id,
+        include_defaults=True,
+        site_id=existing_site.site_id,
     )
 
     # One call to control count for each site control group
@@ -151,7 +157,9 @@ async def test_program_fetch_for_scope(
     # Assert
     assert result is mapped_program
 
-    mock_select_site_control_group_by_id.assert_called_once_with(mock_session, derp_id, include_default=True)
+    mock_select_site_control_group_by_id.assert_called_once_with(
+        mock_session, derp_id, include_default=True, site_id=existing_site.site_id
+    )
     mock_select_single_site_with_site_id.assert_called_once_with(mock_session, scope.site_id, scope.aggregator_id)
     mock_count_active_does_include_deleted.assert_called_once_with(
         mock_session, derp_id, existing_site, now, datetime.min
@@ -207,7 +215,8 @@ async def test_program_fetch_site_control_group_dne(
     derp_id = 76662
 
     mock_session = create_mock_session()
-    mock_select_single_site_with_site_id.return_value = generate_class_instance(Site)
+    existing_site = generate_class_instance(Site)
+    mock_select_single_site_with_site_id.return_value = existing_site
     mock_select_site_control_group_by_id.return_value = None
     scope = generate_class_instance(SiteRequestScope)
 
@@ -216,7 +225,9 @@ async def test_program_fetch_site_control_group_dne(
         await DERProgramManager.fetch_doe_program_for_scope(mock_session, scope, derp_id)
 
     # Assert
-    mock_select_site_control_group_by_id.assert_called_once_with(mock_session, derp_id, include_default=True)
+    mock_select_site_control_group_by_id.assert_called_once_with(
+        mock_session, derp_id, include_default=True, site_id=existing_site.site_id
+    )
     mock_select_single_site_with_site_id.assert_called_once_with(mock_session, scope.site_id, scope.aggregator_id)
     mock_count_active_does_include_deleted.assert_not_called()
     mock_DERProgramMapper.doe_program_response.assert_not_called()

--- a/tests/unit/server/manager/test_end_device.py
+++ b/tests/unit/server/manager/test_end_device.py
@@ -410,6 +410,7 @@ def test_lfdi_matches(lhs: str | None, rhs: str | None, expected: bool):
 
 
 @pytest.mark.anyio
+@mock.patch("envoy.server.manager.end_device.assign_default_site_groups_to_site")
 @mock.patch("envoy.server.manager.end_device.NotificationManager")
 @mock.patch("envoy.server.manager.end_device.insert_site_for_aggregator")
 @mock.patch("envoy.server.manager.end_device.EndDeviceMapper")
@@ -423,6 +424,7 @@ async def test_add_enddevice_for_scope_aggregator_with_sfdi(
     mock_EndDeviceMapper: mock.MagicMock,
     mock_insert_site_for_aggregator: mock.MagicMock,
     mock_NotificationManager: mock.MagicMock,
+    mock_assign_default_site_groups_to_site: mock.MagicMock,
 ):
     """Checks that the enddevice update for an aggregator just passes through to the relevant CRUD (assuming the
     sfdi is specified)"""
@@ -440,6 +442,7 @@ async def test_add_enddevice_for_scope_aggregator_with_sfdi(
     mock_insert_site_for_aggregator.return_value = 4321
     mock_utc_now.return_value = now
     mock_NotificationManager.notify_changed_deleted_entities = mock.Mock(return_value=create_async_result(True))
+    mock_assign_default_site_groups_to_site.return_value = None
 
     # Act
     returned_site_id = await EndDeviceManager.add_enddevice_for_scope(mock_session, scope, end_device)
@@ -452,6 +455,9 @@ async def test_add_enddevice_for_scope_aggregator_with_sfdi(
     mock_insert_site_for_aggregator.assert_called_once_with(mock_session, scope.aggregator_id, mapped_site)
     mock_utc_now.assert_called_once()
     mock_select_single_site_with_sfdi.assert_not_called()
+    mock_assign_default_site_groups_to_site.assert_called_once_with(
+        mock_session, mock_insert_site_for_aggregator.return_value, now
+    )
     mock_NotificationManager.notify_changed_deleted_entities.assert_called_once_with(
         mock.ANY, SubscriptionResource.SITE, now
     )
@@ -495,7 +501,10 @@ async def test_add_enddevice_for_scope_aggregator_lfdi_matches_aggregator_case_i
 
 
 @pytest.mark.anyio
-async def test_add_enddevice_for_scope_device_missing_lfdi() -> None:
+@mock.patch("envoy.server.manager.end_device.assign_default_site_groups_to_site")
+async def test_add_enddevice_for_scope_device_missing_lfdi(
+    mock_assign_default_site_groups_to_site: mock.MagicMock,
+) -> None:
     """Checks that the enddevice update for a device cert is allowable for missing lfdi"""
     # Arrange
     mock_session = create_mock_session()
@@ -507,11 +516,14 @@ async def test_add_enddevice_for_scope_device_missing_lfdi() -> None:
     end_device.sFDI = scope.sfdi  # SFDI matches
     end_device.lFDI = None  # LFDI not provided
 
+    mock_assign_default_site_groups_to_site.return_value = None
+
     # Act
     await EndDeviceManager.add_enddevice_for_scope(mock_session, scope, end_device)
 
     # Assert
     assert_mock_session(mock_session, committed=True)
+    mock_assign_default_site_groups_to_site.assert_called_once()
 
 
 @pytest.mark.anyio
@@ -538,6 +550,7 @@ async def test_add_enddevice_for_scope_device_missing_sfdi(
 
 
 @pytest.mark.anyio
+@mock.patch("envoy.server.manager.end_device.assign_default_site_groups_to_site")
 @mock.patch("envoy.server.manager.end_device.NotificationManager")
 @mock.patch("envoy.server.manager.end_device.insert_site_for_aggregator")
 @mock.patch("envoy.server.manager.end_device.EndDeviceMapper")
@@ -549,6 +562,7 @@ async def test_add_enddevice_for_scope_device(
     mock_EndDeviceMapper: mock.MagicMock,
     mock_insert_site_for_aggregator: mock.MagicMock,
     mock_NotificationManager: mock.MagicMock,
+    mock_assign_default_site_groups_to_site: mock.MagicMock,
 ):
     """Checks that the enddevice update just passes through to the relevant CRUD (assuming the lfdi/sfdi match scope)"""
     # Arrange
@@ -567,6 +581,7 @@ async def test_add_enddevice_for_scope_device(
     mock_EndDeviceMapper.map_from_request = mock.Mock(return_value=mapped_site)
     mock_insert_site_for_aggregator.return_value = 4321
     mock_utc_now.return_value = now
+    mock_assign_default_site_groups_to_site.return_value = None
 
     # Act
     returned_site_id = await EndDeviceManager.add_enddevice_for_scope(mock_session, scope, end_device)
@@ -578,12 +593,16 @@ async def test_add_enddevice_for_scope_device(
     mock_EndDeviceMapper.map_from_request.assert_called_once_with(end_device, scope.aggregator_id, now, 55312)
     mock_insert_site_for_aggregator.assert_called_once_with(mock_session, scope.aggregator_id, mapped_site)
     mock_utc_now.assert_called_once()
+    mock_assign_default_site_groups_to_site.assert_called_once_with(
+        mock_session, mock_insert_site_for_aggregator.return_value, now
+    )
     mock_NotificationManager.notify_changed_deleted_entities.assert_called_once_with(
         mock.ANY, SubscriptionResource.SITE, now
     )
 
 
 @pytest.mark.anyio
+@mock.patch("envoy.server.manager.end_device.assign_default_site_groups_to_site")
 @mock.patch("envoy.server.manager.end_device.NotificationManager")
 @mock.patch("envoy.server.manager.end_device.insert_site_for_aggregator")
 @mock.patch("envoy.server.manager.end_device.EndDeviceMapper")
@@ -595,6 +614,7 @@ async def test_add_enddevice_for_scope_device_lfdi_case_insensitive(
     mock_EndDeviceMapper: mock.MagicMock,
     mock_insert_site_for_aggregator: mock.MagicMock,
     mock_NotificationManager: mock.MagicMock,
+    mock_assign_default_site_groups_to_site: mock.MagicMock,
 ):
     """Checks that lfdi/sfdi from the scope are compared against a lower case version of the requested lfdi"""
     # Arrange
@@ -613,6 +633,7 @@ async def test_add_enddevice_for_scope_device_lfdi_case_insensitive(
     mock_EndDeviceMapper.map_from_request = mock.Mock(return_value=mapped_site)
     mock_insert_site_for_aggregator.return_value = 4321
     mock_utc_now.return_value = now
+    mock_assign_default_site_groups_to_site.return_value = None
 
     # Act
     returned_site_id = await EndDeviceManager.add_enddevice_for_scope(mock_session, scope, end_device)
@@ -624,6 +645,9 @@ async def test_add_enddevice_for_scope_device_lfdi_case_insensitive(
     mock_EndDeviceMapper.map_from_request.assert_called_once_with(end_device, scope.aggregator_id, now, 55312)
     mock_insert_site_for_aggregator.assert_called_once_with(mock_session, scope.aggregator_id, mapped_site)
     mock_utc_now.assert_called_once()
+    mock_assign_default_site_groups_to_site.assert_called_once_with(
+        mock_session, mock_insert_site_for_aggregator.return_value, now
+    )
     mock_NotificationManager.notify_changed_deleted_entities.assert_called_once_with(
         mock.ANY, SubscriptionResource.SITE, now
     )

--- a/tests/unit/server/manager/test_pricing.py
+++ b/tests/unit/server/manager/test_pricing.py
@@ -162,8 +162,8 @@ async def test_fetch_tariff_profile_list(
 
     # Assert
     assert response is mapped_tariffs
-    mock_select_all_tariffs.assert_called_once_with(mock_session, start, changed, limit, fsa_id)
-    mock_select_tariff_count.assert_called_once_with(mock_session, changed, fsa_id)
+    mock_select_all_tariffs.assert_called_once_with(mock_session, start, changed, limit, fsa_id, site_id=scope.site_id)
+    mock_select_tariff_count.assert_called_once_with(mock_session, changed, fsa_id, site_id=scope.site_id)
     assert_mock_session(mock_session)
 
     # We called count_unique_rate_days for each tariff returned
@@ -250,7 +250,7 @@ async def test_fetch_tariff_profile(
     response = await TariffProfileManager.fetch_tariff_profile(mock_session, scope, tariff_id)
     assert response is mapped_tp
 
-    mock_select_single_tariff.assert_called_once_with(mock_session, tariff_id)
+    mock_select_single_tariff.assert_called_once_with(mock_session, tariff_id, site_id=scope.site_id)
     expected_count = rates * TOTAL_PRICING_READING_TYPES
     mock_TariffProfileMapper.map_to_response.assert_called_once_with(scope, tariff, expected_count)
     assert_mock_session(mock_session)
@@ -269,7 +269,7 @@ async def test_fetch_tariff_profile_missing(mock_select_single_tariff: mock.Magi
     response = await TariffProfileManager.fetch_tariff_profile(mock_session, scope, tariff_id)
     assert response is None
 
-    mock_select_single_tariff.assert_called_once_with(mock_session, tariff_id)
+    mock_select_single_tariff.assert_called_once_with(mock_session, tariff_id, site_id=scope.site_id)
     assert_mock_session(mock_session)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'" },
     { name = "cryptography" },
     { name = "defusedxml", marker = "extra == 'test'" },
-    { name = "envoy-schema", specifier = "==1.2.2" },
+    { name = "envoy-schema", specifier = "==1.2.3" },
     { name = "fastapi", specifier = ">=0.94.1,<0.137" },
     { name = "fastapi-async-sqlalchemy" },
     { name = "freezegun", marker = "extra == 'test'" },
@@ -511,15 +511,15 @@ provides-extras = ["dev", "test"]
 
 [[package]]
 name = "envoy-schema"
-version = "1.2.2"
+version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "pydantic-xml", extra = ["lxml"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1a/86/932043ec8e905d3de801bb428a2e8251adb098a6906a04c46dd0a379350c/envoy_schema-1.2.2.tar.gz", hash = "sha256:b9c22abf6c651e844977c732b1fe480b3fef112fed350acd9744150398a0e5c3", size = 41908, upload-time = "2026-07-28T06:07:36.628Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/fd/89539906fbd2ce518d48968698a0bb24a79fd2388353f775dec556244a15/envoy_schema-1.2.3.tar.gz", hash = "sha256:6f8893e3a0efb70dc78c1fe43adbcd2305c0670446e5eafc07230edcbc1bd9e3", size = 41943, upload-time = "2026-07-29T00:31:00.728Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/84/4f559647b21b563d3ea674869d9899eca8bac06744d3836d192d02690461/envoy_schema-1.2.2-py3-none-any.whl", hash = "sha256:56fda203e881d45fb31feefeebe8bfdc401332aedb5bebd2fc5a14210fcb4f8e", size = 54505, upload-time = "2026-07-28T06:07:35.196Z" },
+    { url = "https://files.pythonhosted.org/packages/43/2f/d40d08164831ae96708eb6cc5869b6b27fddd44c837e91e54c6700daf9b2/envoy_schema-1.2.3-py3-none-any.whl", hash = "sha256:29c7950131c15215fee031ddb98f7f5e4ba27743849a8b3e3c2599529f39cb05", size = 54568, upload-time = "2026-07-29T00:30:59.274Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -475,7 +475,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'dev'" },
     { name = "cryptography" },
     { name = "defusedxml", marker = "extra == 'test'" },
-    { name = "envoy-schema", specifier = "==1.2.1" },
+    { name = "envoy-schema", specifier = "==1.2.2" },
     { name = "fastapi", specifier = ">=0.94.1,<0.137" },
     { name = "fastapi-async-sqlalchemy" },
     { name = "freezegun", marker = "extra == 'test'" },
@@ -511,15 +511,15 @@ provides-extras = ["dev", "test"]
 
 [[package]]
 name = "envoy-schema"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "pydantic-xml", extra = ["lxml"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/34/c06407ff493ab90727395f5a01c6d498aa3abdc3e537605528d10aeafe7f/envoy_schema-1.2.1.tar.gz", hash = "sha256:e7d61b09e21c086b8909e5d0fedc7df5943417494cd1ca4291fbe3a80cdd2b35", size = 41784, upload-time = "2026-07-27T05:13:06.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/86/932043ec8e905d3de801bb428a2e8251adb098a6906a04c46dd0a379350c/envoy_schema-1.2.2.tar.gz", hash = "sha256:b9c22abf6c651e844977c732b1fe480b3fef112fed350acd9744150398a0e5c3", size = 41908, upload-time = "2026-07-28T06:07:36.628Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/f6/a06761cd8af87230c1fc9ac6ca68ef24fb6f7c16094a2d64477a51c3e510/envoy_schema-1.2.1-py3-none-any.whl", hash = "sha256:461b765857e8b009a9ed91726857fd465a1b2e93d41e69a7e5d20e6bc55e4c94", size = 54380, upload-time = "2026-07-27T05:13:05.513Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/84/4f559647b21b563d3ea674869d9899eca8bac06744d3836d192d02690461/envoy_schema-1.2.2-py3-none-any.whl", hash = "sha256:56fda203e881d45fb31feefeebe8bfdc401332aedb5bebd2fc5a14210fcb4f8e", size = 54505, upload-time = "2026-07-28T06:07:35.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* SiteGroup now can be marked as default -this means any in-band registration will automatically be added to any default groups

* SiteControlGroup and Tariff can be "restricted" to a single group (or left global as they currently are).